### PR TITLE
fix: resolve 10 consecutive-failure source alerts (#2660-#2669)

### DIFF
--- a/prisma/migrations/20260813120000_disable_topend_h3_hareline/migration.sql
+++ b/prisma/migrations/20260813120000_disable_topend_h3_hareline/migration.sql
@@ -1,0 +1,34 @@
+-- Disable the Top End Hash Hareline (Darwin, top-end-h3) ICAL_FEED source (#2662).
+--
+-- topendhash.com's WordPress + Events Manager site is gone. Every URL under the
+-- domain — the homepage AND the iCal export path
+-- (/?post_type=event&ical=1&limit=50) — now resolves to a GoDaddy "Great things
+-- are coming soon" domain-parking page (verified live 2026-08-12), not a 404 or a
+-- plugin-removed error page. The whole site was torn down, not just the calendar
+-- plugin, so no parser fix is possible.
+--
+-- The club (Topend HHH, Thursdays 1800) is still listed as active on the
+-- official HHH directory (hhh.asn.au) but its only other online presence is a
+-- private Facebook GROUP (facebook.com/groups/TopEndHash) — Groups require
+-- login and are not reachable by the FACEBOOK_HOSTED_EVENTS adapter, which only
+-- scrapes public Pages' /upcoming_hosted_events tab. No replacement source
+-- exists to cut over to (unlike hashnyc's HTML->iCal cutover), so this is a
+-- straight disable rather than a swap.
+--
+-- DATA-ONLY. Vercel runs `prisma migrate deploy`, never `db seed`, so this
+-- migration disables the source directly. A later `db seed` converges the same
+-- row as a no-op (prisma/seed-data/sources.ts carries `enabled: false`).
+--
+-- Idempotent: only touches an *enabled* row of this exact name+type. Safe to
+-- re-apply. Re-enable (here and in seed) if the club relaunches a public feed.
+
+BEGIN;
+
+UPDATE "Source"
+SET enabled = false,
+    "updatedAt" = NOW() AT TIME ZONE 'UTC'
+WHERE name = 'Top End Hash Hareline'
+  AND type::text = 'ICAL_FEED'
+  AND enabled = true;
+
+COMMIT;

--- a/prisma/migrations/20260814090000_narrow_cah3_scrapedays/migration.sql
+++ b/prisma/migrations/20260814090000_narrow_cah3_scrapedays/migration.sql
@@ -1,0 +1,35 @@
+-- Narrow the Cha-Am H3 Website (HTML_SCRAPER) source's scrapeDays from 365
+-- to 150 to close a false-cancellation risk found in #2668 PR review.
+--
+-- The adapter always fetches a FIXED 20 most-recent WordPress posts
+-- (fetchWordPressPosts(baseUrl, 20)) and ignores `options.days` entirely, so
+-- its true ground-truth horizon is however far back those 20 posts reach —
+-- NOT the configured scrapeDays. reconcile.ts uses the SAME scrapeDays value
+-- as its own cancellation window (there is no adapter->reconcile channel for
+-- "I only actually covered N days"), so scrapeDays=365 against a ~150-200
+-- day real fetch horizon risked reconcile marking a genuinely still-live
+-- event CANCELLED just because it fell outside the last-20-posts batch.
+--
+-- Live evidence 2026-08-14: only 2 of the 20 most-recently-fetched posts had
+-- a parseable date at all (the site redesigned its post template with no
+-- date field — see #2668), and the older of the two was already dated
+-- 2026-01-19, ~207 days back. 150 stays safely under that observed floor.
+--
+-- DATA-ONLY. Vercel runs `prisma migrate deploy`, never `db seed`, so this
+-- migration updates the existing prod row directly. A later `db seed`
+-- converges the same value as a no-op (prisma/seed-data/sources.ts already
+-- carries scrapeDays: 150). Idempotent: only touches a row that still has
+-- the old 365 value. Safe to re-apply. Does NOT touch the "Cha-Am H3 Static
+-- Schedule" sibling source — that source generates synthetic events
+-- algorithmically, not via a bounded fetch, so its 365-day window is safe.
+
+BEGIN;
+
+UPDATE "Source"
+SET "scrapeDays" = 150,
+    "updatedAt" = NOW() AT TIME ZONE 'UTC'
+WHERE name = 'Cha-Am H3 Website'
+  AND type::text = 'HTML_SCRAPER'
+  AND "scrapeDays" = 365;
+
+COMMIT;

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -6385,13 +6385,27 @@ export const SOURCES = [
     // "Songkran Outstation APR 10 & 11") and rejects the rest. Pair with
     // the STATIC_SCHEDULE source below so the recurring biweekly Saturday
     // slot still shows on the hareline.
+    //
+    // scrapeDays is intentionally < the historical 365 default (#2668 PR
+    // review): the adapter always fetches a FIXED 20 most-recent posts
+    // (fetchWordPressPosts(baseUrl, 20)), ignoring `options.days` entirely,
+    // so its true ground-truth horizon is however far back those 20 posts
+    // reach — NOT the configured scrapeDays. reconcile.ts uses the SAME
+    // scrapeDays as its cancellation window (there's no adapter->reconcile
+    // channel for "I only covered N days"), so a scrapeDays wider than what
+    // was actually fetched risks false-cancelling a genuine event that's
+    // still live on the site but fell outside the 20-post batch. Live
+    // evidence 2026-08-14: only 2 of the 20 fetched posts had a parseable
+    // date at all, and the older of the two (#529) was already dated
+    // 2026-01-19 — ~207 days back. 150 stays safely under that observed
+    // floor while still giving reconcile a meaningful window.
     {
       name: "Cha-Am H3 Website",
       url: "https://cah3.net",
       type: "HTML_SCRAPER" as const,
       trustLevel: 7,
       scrapeFreq: "daily",
-      scrapeDays: 365,
+      scrapeDays: 150,
       config: {},
       kennelCodes: ["cah3"],
     },

--- a/prisma/seed-data/sources.ts
+++ b/prisma/seed-data/sources.ts
@@ -5746,13 +5746,23 @@ export const SOURCES = [
       kennelCodes: ["perth-h3"],
     },
 
-    // 2. Top End Hash (Darwin) — WordPress + Events Manager plugin.
-    // Events Manager exposes iCal at /?post_type=event&ical=1&limit=50.
-    // Feed mixes past + future events; the iCal adapter window-filters.
+    // 2. Top End Hash (Darwin) — DISABLED (#2662): topendhash.com's WordPress +
+    // Events Manager site is gone. Every URL under the domain (root and the
+    // iCal export path) now resolves to a GoDaddy "Great things are coming
+    // soon" domain-parking page (verified live 2026-08-12), not a 404 or a
+    // plugin-removed error — the whole site was torn down, not just the
+    // calendar. The club is still listed as active on the official HHH
+    // directory (hhh.asn.au, Thursdays 1800) with a private Facebook GROUP
+    // (facebook.com/groups/TopEndHash) as its only other online presence —
+    // Groups require login and aren't reachable by the FACEBOOK_HOSTED_EVENTS
+    // adapter (public Pages' /upcoming_hosted_events only). No parser fix is
+    // possible against a parked domain; re-enable if the club relaunches a
+    // public feed.
     {
       name: "Top End Hash Hareline",
       url: "https://topendhash.com/?post_type=event&ical=1&limit=50",
       type: "ICAL_FEED" as const,
+      enabled: false,
       trustLevel: 8,
       scrapeFreq: "daily",
       scrapeDays: 180,

--- a/src/adapters/html-scraper/cah3.test.ts
+++ b/src/adapters/html-scraper/cah3.test.ts
@@ -1,4 +1,24 @@
-import { parseCah3Title, parseCah3Body, parseCah3Post } from "./cah3";
+import { parseCah3Title, parseCah3Body, parseCah3Post, Cah3Adapter } from "./cah3";
+import * as wordpressApi from "../wordpress-api";
+
+vi.mock("../wordpress-api");
+
+const MONTH_NAMES = [
+  "JAN", "FEB", "MAR", "APR", "MAY", "JUN",
+  "JUL", "AUG", "SEP", "OCT", "NOV", "DEC",
+];
+
+/** A near-future date (~3 weeks out) as "YYYY-MM-DD", plus its "MMM D" title
+ *  form — used so fetch()-level tests stay inside the 365-day scrape window
+ *  indefinitely instead of aging out on a hardcoded year (see
+ *  adapter-patterns.md "windowed adapter tests need relative dates"). */
+function nearFutureDate(): { iso: string; titleText: string } {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() + 21);
+  const iso = d.toISOString().slice(0, 10);
+  const titleText = `${MONTH_NAMES[d.getUTCMonth()]} ${d.getUTCDate()}`;
+  return { iso, titleText };
+}
 
 describe("parseCah3Title", () => {
   it("parses run number and date from a typical title", () => {
@@ -127,5 +147,81 @@ describe("parseCah3Post", () => {
     });
     expect(result.ok).toBe(true);
     if (result.ok) expect(result.event.startTime).toBe("16:00");
+  });
+});
+
+describe("Cah3Adapter.fetch — no-date skip vs. hard failure (#2668)", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  // cah3.net redesigned its "Run NNN" posts mid-2026 onto a template with no
+  // date field anywhere; a majority of posts are expected to skip on
+  // "no-date" as steady state (paired with a STATIC_SCHEDULE sibling source
+  // for the recurring baseline — see seed comment). That expected partial
+  // skip must NOT surface as `errors` (which drives consecutive-failure
+  // alerts) as long as at least one post still yields a dated event.
+  it("does not push no-date skips into errors when some posts still parse", async () => {
+    const { iso, titleText } = nearFutureDate();
+    vi.mocked(wordpressApi.fetchWordPressPosts).mockResolvedValueOnce({
+      posts: [
+        {
+          title: `Run 534: Songkran Outstation ${titleText}`,
+          content: "<p>RUN DIRECTIONS</p>",
+          url: "https://cah3.net/run-534/",
+          date: `${iso}T09:00:00`,
+        },
+        {
+          // New template, real content, but genuinely no date anywhere.
+          title: "Run 541: Bangs My Sister & Brother Lover",
+          content: "<p>Sam Phan Nam Spillway West</p>",
+          url: "https://cah3.net/run-541/",
+          date: `${iso}T11:19:21`,
+        },
+      ],
+      fetchDurationMs: 150,
+    });
+
+    const result = await new Cah3Adapter().fetch({
+      id: "test-cah3",
+      url: "https://cah3.net",
+      scrapeDays: 365,
+    } as never);
+
+    expect(result.events).toHaveLength(1);
+    expect(result.errors).toEqual([]);
+    expect(result.diagnosticContext).toMatchObject({
+      postsFound: 2,
+      eventsParsed: 1,
+      skippedNoDate: 1,
+    });
+  });
+
+  it("escalates to a hard error when every post fetched lacks a date", async () => {
+    const { iso } = nearFutureDate();
+    vi.mocked(wordpressApi.fetchWordPressPosts).mockResolvedValueOnce({
+      posts: [
+        {
+          title: "Run 541: Bangs My Sister & Brother Lover",
+          content: "<p>Sam Phan Nam Spillway West</p>",
+          url: "https://cah3.net/run-541/",
+          date: `${iso}T11:19:21`,
+        },
+        {
+          title: "Run 540: Majestic Ballcock & HTT",
+          content: "<p>GPS Coordinates N 12.5248534</p>",
+          url: "https://cah3.net/run-540/",
+          date: `${iso}T10:26:59`,
+        },
+      ],
+      fetchDurationMs: 150,
+    });
+
+    const result = await new Cah3Adapter().fetch({
+      id: "test-cah3",
+      url: "https://cah3.net",
+      scrapeDays: 365,
+    } as never);
+
+    expect(result.events).toHaveLength(0);
+    expect(result.errors.length).toBeGreaterThan(0);
   });
 });

--- a/src/adapters/html-scraper/cah3.test.ts
+++ b/src/adapters/html-scraper/cah3.test.ts
@@ -161,7 +161,8 @@ describe("Cah3Adapter.fetch — no-date skip vs. hard failure (#2668)", () => {
   // alerts) as long as at least one post still yields a dated event.
   it("does not push no-date skips into errors when some posts still parse", async () => {
     const { iso, titleText } = nearFutureDate();
-    vi.mocked(wordpressApi.fetchWordPressPosts).mockResolvedValueOnce({
+    vi.mocked(wordpressApi.fetchWordPressRunPosts).mockResolvedValueOnce({
+      ok: true,
       posts: [
         {
           title: `Run 534: Songkran Outstation ${titleText}`,
@@ -197,7 +198,8 @@ describe("Cah3Adapter.fetch — no-date skip vs. hard failure (#2668)", () => {
 
   it("escalates to a hard error when every post fetched lacks a date", async () => {
     const { iso } = nearFutureDate();
-    vi.mocked(wordpressApi.fetchWordPressPosts).mockResolvedValueOnce({
+    vi.mocked(wordpressApi.fetchWordPressRunPosts).mockResolvedValueOnce({
+      ok: true,
       posts: [
         {
           title: "Run 541: Bangs My Sister & Brother Lover",

--- a/src/adapters/html-scraper/cah3.ts
+++ b/src/adapters/html-scraper/cah3.ts
@@ -1,7 +1,7 @@
 import type { Source } from "@/generated/prisma/client";
 import type { ErrorDetails, RawEventData, ScrapeResult, SourceAdapter } from "../types";
 import { hasAnyErrors } from "../types";
-import { fetchWordPressPosts } from "../wordpress-api";
+import { fetchWordPressRunPosts } from "../wordpress-api";
 import {
   applyDateWindow,
   chronoParseDate,
@@ -173,14 +173,10 @@ export class Cah3Adapter implements SourceAdapter {
     const errors: string[] = [];
     const errorDetails: ErrorDetails = {};
 
-    const wpResult = await fetchWordPressPosts(baseUrl, 20);
-    if (wpResult.error || wpResult.posts.length === 0) {
-      const message = wpResult.error?.message ?? "CAH3 WordPress API returned no posts";
-      errorDetails.fetch = [
-        { url: baseUrl, message, status: wpResult.error?.status },
-      ];
-      return { events: [], errors: [message], errorDetails };
-    }
+    const wpResult = await fetchWordPressRunPosts(baseUrl, {
+      noPostsMessage: "CAH3 WordPress API returned no posts",
+    });
+    if (!wpResult.ok) return wpResult.result;
 
     // #2668: cah3.net redesigned its "Run NNN" posts around mid-2026 onto a
     // generic "RUN DIRECTIONS / SPECIAL NOTE / ON AFTER" template that has NO

--- a/src/adapters/html-scraper/cah3.ts
+++ b/src/adapters/html-scraper/cah3.ts
@@ -182,7 +182,23 @@ export class Cah3Adapter implements SourceAdapter {
       return { events: [], errors: [message], errorDetails };
     }
 
+    // #2668: cah3.net redesigned its "Run NNN" posts around mid-2026 onto a
+    // generic "RUN DIRECTIONS / SPECIAL NOTE / ON AFTER" template that has NO
+    // date field anywhere (title or body) — confirmed live 2026-08-13 by
+    // inspecting the raw WP REST payload (no ACF/meta date field either).
+    // The site's own /hareline/ page now points hares at a Facebook Events
+    // page for scheduling instead. This was already a known, by-design
+    // partial-parse source (see the seed comment: "~20% of posts whose
+    // titles do carry dates ... rejects the rest", paired with a
+    // STATIC_SCHEDULE source for the recurring baseline) — the redesign just
+    // pushed the miss rate higher. A per-post "no parseable date" skip here
+    // is expected steady state, not format drift, so it's tracked as a
+    // diagnostic count rather than pushed into `errors` (which drives
+    // consecutive-failure alerts). Only escalate to a hard error if literally
+    // NO posts yield a dated event — that would mean the ~20% baseline itself
+    // broke, which the STATIC_SCHEDULE sibling can't detect on its own.
     const events: RawEventData[] = [];
+    const noDateTitles: string[] = [];
     for (let i = 0; i < wpResult.posts.length; i++) {
       const post = wpResult.posts[i];
       const result = parseCah3Post({
@@ -196,7 +212,7 @@ export class Cah3Adapter implements SourceAdapter {
         continue;
       }
       if (result.reason === "not-run-post") continue;
-      errors.push(`CAH3 post "${result.title.slice(0, 80)}" has no parseable date`);
+      noDateTitles.push(result.title.slice(0, 80));
       errorDetails.parse = [
         ...(errorDetails.parse ?? []),
         {
@@ -209,6 +225,12 @@ export class Cah3Adapter implements SourceAdapter {
       ];
     }
 
+    if (events.length === 0 && noDateTitles.length > 0) {
+      errors.push(
+        `CAH3: ${noDateTitles.length} post(s) fetched but none had a parseable date — the ~20% title-date baseline may have broken`,
+      );
+    }
+
     const days = options?.days ?? source.scrapeDays ?? 365;
     return applyDateWindow(
       {
@@ -219,6 +241,8 @@ export class Cah3Adapter implements SourceAdapter {
           fetchMethod: "wordpress-api",
           postsFound: wpResult.posts.length,
           eventsParsed: events.length,
+          skippedNoDate: noDateTitles.length,
+          skippedNoDateTitles: noDateTitles,
           fetchDurationMs: wpResult.fetchDurationMs,
         },
       },

--- a/src/adapters/html-scraper/hash-horrors.test.ts
+++ b/src/adapters/html-scraper/hash-horrors.test.ts
@@ -177,6 +177,41 @@ describe("parseHashHorrorsHareline (year-grouped archive)", () => {
     expect(out.skippedMarkers).toBe(1);
   });
 
+  it("does not mistake a Singapore postal-code fragment for a run-line start (#2666)", () => {
+    // Live 2026-08-13: "...Singapore 099115 – Bottom of Mount Faber..." — the
+    // trailing 4 digits of the postal code ("9115") plus " – Bottom" satisfy
+    // the digits+dash+word shape and were previously mis-tokenized as a
+    // (unparseable) run-line start, inflating skippedLines every scrape.
+    const text =
+      "2026 790 – November 9 – Duncan Family – Mount Faber – near 4 Seah Im Road, " +
+      "Singapore 099115 – Bottom of Mount Faber / Large Car Park off Seah Im Rd. " +
+      "789 – October 26 – Strawberry Short-Cut, Gummy Bear";
+    const out = parseHashHorrorsHareline(text);
+    expect(out.events.map((e) => e.runNumber)).toEqual([790, 789]);
+    expect(out.skippedLines).toBe(0);
+  });
+
+  it("skips known-dateless 1990s/2000s archive stub rows without counting as drift (#2666)", () => {
+    // These run numbers genuinely have no month/day in the source's own
+    // /hareline page (verified live 2026-08-13) — not a parser regression.
+    const text =
+      "2004 640 – February 8 – Abe, Ella and Sil Linskens – Upper Peirce Reservoir Park " +
+      "628 – Linskens and Seah Families – Upper Peirce Reservoir " +
+      "625 – Danial, Mushu, and Mischief – Lorong Lada Hitam " +
+      "600 – July 29";
+    const out = parseHashHorrorsHareline(text);
+    expect(out.events.map((e) => e.runNumber)).toEqual([640, 600]);
+    expect(out.skippedLines).toBe(0);
+    expect(out.skippedKnownGaps).toBe(2);
+  });
+
+  it("still counts an unrecognized dateless run number as skippedLines drift (allowlist doesn't over-match)", () => {
+    const text = "2004 640 – February 8 – Abe Family 601 – Nobody Knows This One";
+    const out = parseHashHorrorsHareline(text);
+    expect(out.skippedKnownGaps).toBe(0);
+    expect(out.skippedLines).toBe(1);
+  });
+
   it("flags non-empty pages with no year headings as a parse failure (#1536 review)", () => {
     // If the WP.com template drops the year heading shape entirely, the
     // adapter must surface a scrape error rather than silently emit zero

--- a/src/adapters/html-scraper/hash-horrors.ts
+++ b/src/adapters/html-scraper/hash-horrors.ts
@@ -187,6 +187,29 @@ export interface ParseHarelineResult {
   skippedLines: number;
   /** Run lines that were recognised but intentionally emit no event (e.g. BREAK). */
   skippedMarkers: number;
+  /** Known-dateless historical stub rows, skipped without counting as drift. */
+  skippedKnownGaps: number;
+}
+
+/**
+ * Very old (1994-2004) archive rows for which the kennel's own `/hareline`
+ * page has never carried a month/day — the row is just "<run#> – <hares> –
+ * <location>" with the date field entirely absent from the source HTML
+ * (verified live 2026-08-13, #2666). This is not a parser gap: there is no
+ * date to recover, so no event can ever be emitted for these run numbers.
+ * Treating them as ordinary "skippedLines" would permanently trip the
+ * format-drift alert on every scrape, even though nothing has drifted.
+ * Listed as an explicit allowlist (rather than "any dateless line") so a
+ * *new*, unexpected dateless row still counts as drift and surfaces.
+ */
+const KNOWN_DATELESS_RUN_NUMBERS = new Set([526, 527, 528, 552, 616, 617, 625, 628]);
+
+/** Extract the leading run number from a candidate line, or null if the
+ *  run-prefix shape itself doesn't match (shouldn't happen — callers only
+ *  invoke this on lines `findRunLineStarts` already matched). */
+function extractLeadingRunNumber(line: string): number | null {
+  const m = RUN_PREFIX_RE.exec(line.trim());
+  return m ? Number.parseInt(m[1], 10) : null;
 }
 
 /**
@@ -223,10 +246,20 @@ function findYearHeadings(text: string): Array<{ year: number; start: number; en
  * with a context-aware check (e.g. look backwards from the candidate for an
  * ordinal/space pattern) or shift to a per-row tokenizer. Codex flagged
  * this on PR #1536 as a long-horizon correctness regression.
+ *
+ * The leading `(?<!\d)` guards against a genuine false-positive found live
+ * on 2026-08-13 (#2666): a 1990s archive row embeds a 6-digit Singapore
+ * postal code ("...Seah Im Road, Singapore 099115 – Bottom of Mount
+ * Faber..."). Without the lookbehind, the tokenizer matches the *trailing*
+ * 4 digits of the postal code ("9115") as if it were its own run-number
+ * prefix, since "9115 – Bottom" satisfies the digits+dash+word shape.
+ * Requiring the digit run not be preceded by another digit rejects any
+ * mid-number substring match while leaving every real run-line start
+ * (always preceded by whitespace or start-of-section) unaffected.
  */
 function findRunLineStarts(section: string): number[] {
   const starts: number[] = [];
-  for (const m of section.matchAll(/(\d{3,4})\s*[–—:-]\s*(?:[a-z]+|\d{1,2})/gi)) {
+  for (const m of section.matchAll(/(?<!\d)(\d{3,4})\s*[–—:-]\s*(?:[a-z]+|\d{1,2})/gi)) {
     const n = Number.parseInt(m[1], 10);
     if (n >= 1900 && n <= 2099) continue;
     if (m.index !== undefined) starts.push(m.index);
@@ -263,13 +296,19 @@ function walkRunLines(
   const events: RawEventData[] = [];
   let skippedLines = 0;
   let skippedMarkers = 0;
+  let skippedKnownGaps = 0;
   const starts = findRunLineStarts(text);
   for (let i = 0; i < starts.length; i++) {
     const lineEnd = starts[i + 1] ?? text.length;
     const line = text.slice(starts[i], lineEnd).trim();
     const parsed = parseHashHorrorsRunLine(line);
     if (!parsed) {
-      skippedLines++;
+      const runNumber = extractLeadingRunNumber(line);
+      if (runNumber !== null && KNOWN_DATELESS_RUN_NUMBERS.has(runNumber)) {
+        skippedKnownGaps++;
+      } else {
+        skippedLines++;
+      }
       continue;
     }
     const year = yearForLine(parsed);
@@ -279,7 +318,7 @@ function walkRunLines(
     }
     events.push(buildEvent(parsed, year));
   }
-  return { events, skippedLines, skippedMarkers };
+  return { events, skippedLines, skippedMarkers, skippedKnownGaps };
 }
 
 /**
@@ -295,9 +334,10 @@ export function parseHashHorrorsHareline(text: string): ParseHarelineResult {
   const events: RawEventData[] = [];
   let skippedLines = 0;
   let skippedMarkers = 0;
+  let skippedKnownGaps = 0;
   const headings = findYearHeadings(text);
   if (text.trim() && headings.length === 0) {
-    return { events: [], skippedLines: 1, skippedMarkers: 0 };
+    return { events: [], skippedLines: 1, skippedMarkers: 0, skippedKnownGaps: 0 };
   }
   for (let i = 0; i < headings.length; i++) {
     const { year, end } = headings[i];
@@ -307,8 +347,9 @@ export function parseHashHorrorsHareline(text: string): ParseHarelineResult {
     events.push(...sectionResult.events);
     skippedLines += sectionResult.skippedLines;
     skippedMarkers += sectionResult.skippedMarkers;
+    skippedKnownGaps += sectionResult.skippedKnownGaps;
   }
-  return { events, skippedLines, skippedMarkers };
+  return { events, skippedLines, skippedMarkers, skippedKnownGaps };
 }
 
 /**
@@ -396,7 +437,12 @@ export class HashHorrorsAdapter implements SourceAdapter {
     const fetchErrors: NonNullable<ErrorDetails["fetch"]> = [];
     let upcomingUrl: string | undefined;
     let upcomingText = "";
-    let upcoming: ParseHarelineResult = { events: [], skippedLines: 0, skippedMarkers: 0 };
+    let upcoming: ParseHarelineResult = {
+      events: [],
+      skippedLines: 0,
+      skippedMarkers: 0,
+      skippedKnownGaps: 0,
+    };
 
     if (upcomingResult.error || !upcomingResult.page) {
       const message = upcomingResult.error?.message ?? "WordPress.com API returned no upcoming page";
@@ -435,6 +481,7 @@ export class HashHorrorsAdapter implements SourceAdapter {
 
     const skippedLines = archive.skippedLines + upcoming.skippedLines;
     const skippedMarkers = archive.skippedMarkers + upcoming.skippedMarkers;
+    const skippedKnownGaps = archive.skippedKnownGaps + upcoming.skippedKnownGaps;
 
     // Surface dropped lines as scrape errors so the reconciler doesn't cancel
     // events on a partial parse (it only runs when errors.length === 0). A
@@ -475,6 +522,7 @@ export class HashHorrorsAdapter implements SourceAdapter {
         upcomingRunsParsed: upcoming.events.length,
         skippedLines,
         skippedMarkers,
+        skippedKnownGaps,
         eventsInWindow: events.length,
         archiveFetchDurationMs: archiveResult.fetchDurationMs,
         upcomingFetchDurationMs: upcomingResult.fetchDurationMs,

--- a/src/adapters/html-scraper/hashphilly.test.ts
+++ b/src/adapters/html-scraper/hashphilly.test.ts
@@ -55,6 +55,17 @@ const SAMPLE_HTML_NO_TRAILNUM = `
 </body></html>
 `;
 
+const SAMPLE_HTML_TBD = `
+<html><body>
+<div>
+<p>Trail Number: 2048</p>
+<p>Date: TBD</p>
+<p>Time: TBD</p>
+<p>Location: TBD</p>
+</div>
+</body></html>
+`;
+
 describe("HashPhillyAdapter.fetch", () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -118,6 +129,21 @@ describe("HashPhillyAdapter.fetch", () => {
     expect(result.events).toHaveLength(0);
     expect(result.errors.length).toBeGreaterThan(0);
     expect(result.errors[0]).toContain("date");
+  });
+
+  it("succeeds with zero events (not an error) when Date is a placeholder like 'TBD'", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(SAMPLE_HTML_TBD, { status: 200 }),
+    );
+
+    const adapter = new HashPhillyAdapter();
+    const result = await adapter.fetch({
+      id: "test",
+      url: "https://hashphilly.com/nexthash/",
+    } as never);
+
+    expect(result.events).toHaveLength(0);
+    expect(result.errors).toHaveLength(0);
   });
 
   it("returns error on network failure", async () => {

--- a/src/adapters/html-scraper/hashphilly.test.ts
+++ b/src/adapters/html-scraper/hashphilly.test.ts
@@ -66,6 +66,20 @@ const SAMPLE_HTML_TBD = `
 </body></html>
 `;
 
+// PR review finding (#2661 follow-up): the hyphenated "N-A" spelling wasn't
+// covered by the original placeholder regex, so it fell through to
+// chronoParseDate and re-triggered the same consecutive-failure alert.
+const SAMPLE_HTML_N_DASH_A = `
+<html><body>
+<div>
+<p>Trail Number: 2049</p>
+<p>Date: N-A</p>
+<p>Time: N-A</p>
+<p>Location: N-A</p>
+</div>
+</body></html>
+`;
+
 describe("HashPhillyAdapter.fetch", () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -134,6 +148,21 @@ describe("HashPhillyAdapter.fetch", () => {
   it("succeeds with zero events (not an error) when Date is a placeholder like 'TBD'", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
       new Response(SAMPLE_HTML_TBD, { status: 200 }),
+    );
+
+    const adapter = new HashPhillyAdapter();
+    const result = await adapter.fetch({
+      id: "test",
+      url: "https://hashphilly.com/nexthash/",
+    } as never);
+
+    expect(result.events).toHaveLength(0);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("succeeds with zero events when Date is the hyphenated 'N-A' spelling (PR review finding)", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(SAMPLE_HTML_N_DASH_A, { status: 200 }),
     );
 
     const adapter = new HashPhillyAdapter();

--- a/src/adapters/html-scraper/hashphilly.ts
+++ b/src/adapters/html-scraper/hashphilly.ts
@@ -8,9 +8,11 @@ const mapsUrl = googleMapsSearchUrl;
  * Known placeholder values the site publishes for the "Date" field when the
  * next trail hasn't been scheduled yet (e.g. between events, or hare TBD).
  * These are NOT parse failures — the source is working correctly and simply
- * has nothing to report yet. (#2661)
+ * has nothing to report yet. (#2661) The "N/A" alternative accepts slash,
+ * hyphen, or no separator ("N/A", "N-A", "NA") — PR review flagged that the
+ * hyphenated spelling wasn't covered.
  */
-const DATE_PLACEHOLDER_RE = /^(tbd|tba|n\/?a|coming soon|\?+|-+)$/i;
+const DATE_PLACEHOLDER_RE = /^(tbd|tba|n[-/]?a|coming soon|\?+|-+)$/i;
 
 /**
  * Parse a Philly H3 date string using chrono-node.

--- a/src/adapters/html-scraper/hashphilly.ts
+++ b/src/adapters/html-scraper/hashphilly.ts
@@ -5,6 +5,14 @@ import { chronoParseDate, parse12HourTime, googleMapsSearchUrl, fetchHTMLPage } 
 const mapsUrl = googleMapsSearchUrl;
 
 /**
+ * Known placeholder values the site publishes for the "Date" field when the
+ * next trail hasn't been scheduled yet (e.g. between events, or hare TBD).
+ * These are NOT parse failures — the source is working correctly and simply
+ * has nothing to report yet. (#2661)
+ */
+const DATE_PLACEHOLDER_RE = /^(tbd|tba|n\/?a|coming soon|\?+|-+)$/i;
+
+/**
  * Parse a Philly H3 date string using chrono-node.
  * Handles: "Sat, Feb 14, 2026", "Sat, February 14, 2026"
  */
@@ -53,9 +61,24 @@ export class HashPhillyAdapter implements SourceAdapter {
       return { events: [], errors: ["No date found on page"], structureHash, errorDetails };
     }
 
-    const dateStr = parsePhillyDate(dateMatch[1].trim());
+    const rawDate = dateMatch[1].trim();
+
+    // The site publishes "Date: TBD" between hares stepping up — this is the
+    // expected steady state, not a scraper bug. Succeed with zero events so
+    // consecutive-failure alerts don't fire while the page is legitimately
+    // waiting on a hare. (#2661)
+    if (DATE_PLACEHOLDER_RE.test(rawDate)) {
+      return {
+        events: [],
+        errors: [],
+        structureHash,
+        diagnosticContext: { fieldsFound: ["trailNumber"], nextTrailPending: true },
+      };
+    }
+
+    const dateStr = parsePhillyDate(rawDate);
     if (!dateStr) {
-      const message = `Could not parse date: "${dateMatch[1].trim()}"`;
+      const message = `Could not parse date: "${rawDate}"`;
       errorDetails.parse = [{ row: 0, section: "main", field: "date", error: message, rawText: bodyText.slice(0, 2000), partialData: { kennelTags: ["philly-h3" ]} }];
       return { events: [], errors: [message], structureHash, errorDetails };
     }

--- a/src/adapters/html-scraper/riyadh-h3.test.ts
+++ b/src/adapters/html-scraper/riyadh-h3.test.ts
@@ -1,4 +1,4 @@
-import { RiyadhH3Adapter, mapHikeRow, type HikeRow } from "./riyadh-h3";
+import { RiyadhH3Adapter, mapHikeRow, HIKES_SELECT, type HikeRow } from "./riyadh-h3";
 import { safeFetch } from "../safe-fetch";
 import type { Source } from "@/generated/prisma/client";
 
@@ -121,6 +121,18 @@ describe("mapHikeRow", () => {
     expect(e.description).toBeUndefined();
     expect(e.startTime).toBeUndefined();
     expect(e.latitude).toBeUndefined();
+  });
+});
+
+describe("HIKES_SELECT", () => {
+  // #2665: the site owner revoked the anon role's column-level SELECT grant on
+  // `location_gps` and `map_link`. PostgREST fails the WHOLE request (401) if
+  // ANY requested column lacks a grant, so re-adding either name here would
+  // silently zero out every future Riyadh H3 scrape. Verified live 2026-08-13.
+  it("does not request the anon-revoked location_gps/map_link columns", () => {
+    const columns = HIKES_SELECT.split(",");
+    expect(columns).not.toContain("location_gps");
+    expect(columns).not.toContain("map_link");
   });
 });
 

--- a/src/adapters/html-scraper/riyadh-h3.ts
+++ b/src/adapters/html-scraper/riyadh-h3.ts
@@ -51,9 +51,22 @@ export function riyadhToday(): string {
 }
 
 /** Columns consumed by mapHikeRow — explicit `select` so the wire payload never
- *  carries unused (or future large) columns. Shared with the history backfill. */
+ *  carries unused (or future large) columns. Shared with the history backfill.
+ *
+ *  `location_gps` and `map_link` were dropped in #2665: the site owner revoked
+ *  the anon role's column-level SELECT grant on both (verified live
+ *  2026-08-13 — every other column, including `id`/`date`/`title`/`location`/
+ *  `gathering_time`/`description`, still returns 200; only these two 401 with
+ *  Postgres `permission denied for table hikes`, which is a column-grant error,
+ *  not an RLS/anon-key-rotation error — the anon JWT itself still authenticates
+ *  fine against every other table). PostgREST fails the WHOLE request when any
+ *  requested column lacks a grant, so keeping either column in this list zeros
+ *  out every future scrape. mapHikeRow already treats both fields as optional
+ *  (falls back to geocoding `location` text / the kennel centroid), so this is
+ *  a graceful degrade, not a data-loss regression. Re-add if the grant returns.
+ */
 export const HIKES_SELECT =
-  "run_number,date,title,location,gathering_time,location_gps,map_link,description";
+  "run_number,date,title,location,gathering_time,description";
 
 export interface RiyadhH3Config {
   /** Supabase project ref, e.g. "uleyjftvdnpniabomdpi" → <ref>.supabase.co */

--- a/src/adapters/html-scraper/seven-hills-h3.test.ts
+++ b/src/adapters/html-scraper/seven-hills-h3.test.ts
@@ -72,6 +72,20 @@ describe("parseSevenHillsPage", () => {
     expect(result?.startTime).toBe("18:30");
   });
 
+  it("does not mistake a later on-after time for the trail start time when When: has no time (PR review finding)", () => {
+    // Making "@" optional on TIME_AT_RE (#2663, live "6:30p.m." layout) would
+    // otherwise let it match the FIRST am/pm-shaped text anywhere in the
+    // trail block — here that's the on-after mention, not the trail start —
+    // when the "When:" line itself carries no time at all.
+    const body =
+      "Trail 2029When: August 19, 2026 Start: Jojos Pizza 1400 Lakeside Drive " +
+      "Lynchburg VA 24501Hares: UTB & Mystery HareBeer Meister: No" +
+      "Special Instructions: On-after starts at 8pm at the pub.";
+    const result = parseSevenHillsPage(`<html><body>${body}</body></html>`);
+    expect(result?.startTime).toBeUndefined();
+    expect(result?.date).toMatch(/^\d{4}-08-19$/);
+  });
+
   it("handles missing optional fields gracefully", () => {
     const body = "TRAIL #2011 Another TrailThursday April 9, 2026 @ 6pm";
     const result = parseSevenHillsPage(`<html><body>${body}</body></html>`);

--- a/src/adapters/html-scraper/seven-hills-h3.test.ts
+++ b/src/adapters/html-scraper/seven-hills-h3.test.ts
@@ -22,6 +22,40 @@ describe("parseSevenHillsPage", () => {
     });
   });
 
+  it("parses the live layout (#2663): 'Trail N' with no '#', no day-name, no '@' before the time", () => {
+    // Captured live from sites.google.com/view/7h4/home on 2026-08-13 after
+    // the site dropped the "#", the leading day-of-week, and the "@" before
+    // the time all at once.
+    const body =
+      "Upcoming TrailsTrail 2028When: August 12, 2026 6:30p.m. Start: " +
+      "Jojos Pizza 1400 Lakeside Drive Lynchburg VA 24501Hares: UTB & Mystery Hare" +
+      "Beer Meister: NoSpecial Instructions: A to A.";
+    const result = parseSevenHillsPage(`<html><body>${body}</body></html>`);
+    expect(result).toMatchObject({
+      runNumber: 2028,
+      date: expect.stringMatching(/^\d{4}-08-12$/),
+      startTime: "18:30",
+      hares: "UTB & Mystery Hare",
+      location: "Jojos Pizza 1400 Lakeside Drive Lynchburg VA 24501",
+    });
+  });
+
+  it("does not mistake an earlier day-name-less date in page prose for the trail date (#2663)", () => {
+    // The page's "About Hashing" blurb states the club's 1992 founding date
+    // with no day-of-week attached ("began ... on June 21, 1992"), ahead of
+    // the actual trail block in body order. Once the day-name prefix on
+    // DATE_PHRASE_RE became optional to match the live "August 12, 2026"
+    // layout, an unanchored search would greedily match this 1992 date
+    // instead of the real trail date — the date search must be scoped to
+    // after the "Trail N" match, not the whole body text.
+    const body =
+      "The 7H4 traditions began in Lynchburg, Virginia on June 21, 1992. " +
+      "See you Wednesday!Upcoming TrailsTrail 2028When: August 12, 2026 6:30p.m. " +
+      "Start: Jojos Pizza";
+    const result = parseSevenHillsPage(`<html><body>${body}</body></html>`);
+    expect(result?.date).toMatch(/^\d{4}-08-12$/);
+  });
+
   it("returns null when no TRAIL #N block is present", () => {
     const html = `<html><body>Welcome to the 7H4 home page. No trail announcement yet.</body></html>`;
     expect(parseSevenHillsPage(html)).toBeNull();

--- a/src/adapters/html-scraper/seven-hills-h3.test.ts
+++ b/src/adapters/html-scraper/seven-hills-h3.test.ts
@@ -43,10 +43,10 @@ describe("parseSevenHillsPage", () => {
   it("does not mistake an earlier day-name-less date in page prose for the trail date (#2663)", () => {
     // The page's "About Hashing" blurb states the club's 1992 founding date
     // with no day-of-week attached ("began ... on June 21, 1992"), ahead of
-    // the actual trail block in body order. Once the day-name prefix on
-    // DATE_PHRASE_RE became optional to match the live "August 12, 2026"
-    // layout, an unanchored search would greedily match this 1992 date
-    // instead of the real trail date — the date search must be scoped to
+    // the actual trail block in body order. An unanchored MONTH_DAY_YEAR_RE
+    // search would greedily match this 1992 date instead of the real trail
+    // date (to match the live "August 12, 2026" no-day-name layout) — the
+    // date search must be scoped to
     // after the "Trail N" match, not the whole body text.
     const body =
       "The 7H4 traditions began in Lynchburg, Virginia on June 21, 1992. " +

--- a/src/adapters/html-scraper/seven-hills-h3.ts
+++ b/src/adapters/html-scraper/seven-hills-h3.ts
@@ -94,12 +94,11 @@ export function parseSevenHillsPage(html: string): ParsedTrail | null {
   // Search only the text AFTER "TRAIL #N" / "Trail N" for the date/time/
   // hares/location fields. The page's "About Hashing" prose above the trail
   // block contains the club's founding date ("began in Lynchburg, Virginia
-  // on June 21, 1992") with no leading day-of-week — once DATE_PHRASE_RE's
-  // day-name prefix became optional (#2663, to match the live "August 12,
-  // 2026" no-day-name layout), an unanchored search on the WHOLE body text
-  // matched that 1992 founding date instead of the actual upcoming trail
-  // date. Anchoring to after the trail number guarantees we only ever see
-  // the current trail's own field block.
+  // on June 21, 1992") with no leading day-of-week — an unanchored
+  // MONTH_DAY_YEAR_RE search on the WHOLE body text would match that 1992
+  // founding date instead of the actual upcoming trail date (#2663).
+  // Anchoring to after the trail number guarantees we only ever see the
+  // current trail's own field block.
   const trailBlockStart = trailMatch.index + trailMatch[0].length;
   const trailBlock = bodyText.slice(trailBlockStart);
 

--- a/src/adapters/html-scraper/seven-hills-h3.ts
+++ b/src/adapters/html-scraper/seven-hills-h3.ts
@@ -56,8 +56,11 @@ const DAY_NAME_SUFFIX_RE = /(?:Monday|Tuesday|Wednesday|Thursday|Friday|Saturday
  *  of #2663, verified 2026-08-13). The "@" is optional; the trailing
  *  am/pm suffix is the real anchor so this stays safe against false
  *  matches elsewhere in the body text. Minutes optional either way.
- *  Captured time is normalized into `HH:MM am/pm` before parsing. */
-const TIME_AT_RE = /@?\s*(\d{1,2})(?::(\d{2}))?\s*(a\.?m\.?|p\.?m\.?)/i;
+ *  Captured time is normalized into `HH:MM am/pm` before parsing. A single
+ *  `[@\s]*` class (rather than `@?\s*`) avoids the adjacent-optional-
+ *  quantifier shape Sonar flags as super-linear (S8786), same fix as
+ *  TRAIL_NUMBER_RE above. */
+const TIME_AT_RE = /[@\s]*(\d{1,2})(?::(\d{2}))?\s*(a\.?m\.?|p\.?m\.?)/i;
 /** "Hares: Frodo & Snatch" — up to the next line / label / EOD. */
 const HARES_RE = /Hares?:\s*([^\n]+)/i;
 /** "Start: 442 S Five Forks Road Monroe, VA" — up to the next line / label / EOD. */

--- a/src/adapters/html-scraper/seven-hills-h3.ts
+++ b/src/adapters/html-scraper/seven-hills-h3.ts
@@ -28,18 +28,30 @@ import { fetchHTMLPage, chronoParseDate, parse12HourTime, decodeEntities } from 
  */
 
 /** "TRAIL #2005" (older layout) or "Trail 2028" (live layout as of #2663,
- *  verified 2026-08-13 — the site dropped the "#"). The "#" is optional so
- *  both shapes match. */
-const TRAIL_NUMBER_RE = /TRAIL\s*#?\s*(\d+)/i;
+ *  verified 2026-08-13 — the site dropped the "#"). A single `[\s#]*`
+ *  class (rather than `\s*#?\s*`) avoids the adjacent-optional-quantifier
+ *  shape Sonar flags as super-linear (S8786) while matching the same
+ *  practical inputs. */
+const TRAIL_NUMBER_RE = /TRAIL[\s#]*(\d+)/i;
 /** Day names used for injecting a split before the date phrase. */
 const DATE_SPLIT_RE = /(Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday)/g;
 /** Known field labels on the 7H4 page that need a preceding newline so value regexes don't run past them. */
 const FIELD_LABEL_SPLIT_RE = /(When:|Start:|Hares?:|Beer\s*Meister:|Cost:|Shiggy\s*Level:|Special\s*Instructions:|On[\s-]*On)/g;
-/** "Saturday April 4, 2026" (older layout) or "August 12, 2026" (live layout
- *  as of #2663, verified 2026-08-13 — the site dropped the leading
- *  day-of-week). The day-name + comma prefix is optional so both shapes
- *  match; only the month/day/year is captured either way. */
-const DATE_PHRASE_RE = /(?:(?:Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday),?\s+)?((?:January|February|March|April|May|June|July|August|September|October|November|December)\s+\d{1,2},?\s+\d{4})/i;
+/** "August 12, 2026" (live layout as of #2663, verified 2026-08-13 — the
+ *  site dropped the leading day-of-week the older "Saturday April 4, 2026"
+ *  layout had). Matches ONLY the month/day/year — the optional leading
+ *  day-name is detected separately via {@link DAY_NAME_SUFFIX_RE} so this
+ *  regex isn't also carrying a 7-way alternation nested inside an optional
+ *  group. Combining both into one regex measured Sonar complexity 28 (limit
+ *  20, S5843); splitting them keeps each well under that on its own. */
+const MONTH_DAY_YEAR_RE = /((?:January|February|March|April|May|June|July|August|September|October|November|December)\s+\d{1,2},?\s+\d{4})/i;
+/** Matches a day-of-week (+ optional comma/whitespace) ONLY when it's the
+ *  last thing before the string end — used to check whether the text
+ *  immediately preceding a {@link MONTH_DAY_YEAR_RE} match is a day name,
+ *  so the trail-NAME boundary can be placed before it (see
+ *  parseSevenHillsPage). Split out from MONTH_DAY_YEAR_RE for the same
+ *  Sonar S5843 complexity reason. */
+const DAY_NAME_SUFFIX_RE = /(?:Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday),?\s+$/i;
 /** "@ 2pm" (older layout) or "6:30p.m." with no "@" at all (live layout as
  *  of #2663, verified 2026-08-13). The "@" is optional; the trailing
  *  am/pm suffix is the real anchor so this stays safe against false
@@ -91,13 +103,41 @@ export function parseSevenHillsPage(html: string): ParsedTrail | null {
   const trailBlockStart = trailMatch.index + trailMatch[0].length;
   const trailBlock = bodyText.slice(trailBlockStart);
 
-  const dateMatchInBlock = DATE_PHRASE_RE.exec(trailBlock);
+  const dateMatchInBlock = MONTH_DAY_YEAR_RE.exec(trailBlock);
   if (!dateMatchInBlock) return null;
   const date = chronoParseDate(dateMatchInBlock[1], "en-US", new Date(), { forwardDate: true });
   if (!date) return null;
 
+  // The older layout prefixes the month/day/year with a day-of-week
+  // ("Saturday April 4, 2026"); the live layout doesn't. When present, the
+  // trail-NAME boundary belongs before the day name, not before the month —
+  // otherwise the day name leaks into the extracted title. Checked as a
+  // separate end-anchored regex against the text before the date match
+  // (see DAY_NAME_SUFFIX_RE for why this isn't folded into one regex).
+  const textBeforeDate = trailBlock.slice(0, dateMatchInBlock.index);
+  const dayNameMatch = DAY_NAME_SUFFIX_RE.exec(textBeforeDate);
+  const dateBlockStart = dayNameMatch
+    ? dateMatchInBlock.index - dayNameMatch[0].length
+    : dateMatchInBlock.index;
+
+  // Search for the time ONLY in the span between the end of the date match
+  // and the next injected field-label newline (FIELD_LABEL_SPLIT_RE puts one
+  // before "Start:"/"Hares:"/etc.) — i.e. exactly the text that trails the
+  // "When:"/date line, never further into the block. Making "@" optional on
+  // TIME_AT_RE (#2663, to match the live "6:30p.m." no-"@" layout) otherwise
+  // lets it match ANY am/pm-shaped text in the whole trail block — e.g. a
+  // later "Special Instructions: On-after starts at 8pm" mention — and
+  // misreport the on-after time as the trail start time when the "When:"
+  // line itself carries no time (PR review finding, verified live-shaped).
+  const afterDateStart = dateMatchInBlock.index + dateMatchInBlock[0].length;
+  const nextLabelBreak = trailBlock.indexOf("\n", afterDateStart);
+  const timeSearchZone = trailBlock.slice(
+    afterDateStart,
+    nextLabelBreak === -1 ? undefined : nextLabelBreak,
+  );
+
   // parse12HourTime requires explicit minutes, so synthesize ":00" for the "2pm" short form.
-  const timeMatch = TIME_AT_RE.exec(trailBlock);
+  const timeMatch = TIME_AT_RE.exec(timeSearchZone);
   let startTime: string | undefined;
   if (timeMatch) {
     const hour = timeMatch[1];
@@ -122,7 +162,7 @@ export function parseSevenHillsPage(html: string): ParsedTrail | null {
   // names, so a title like "Saturday Night Fever Trail" would be truncated.
   let title: string | undefined;
   const nameStart = trailBlockStart;
-  const nameEnd = trailBlockStart + dateMatchInBlock.index;
+  const nameEnd = trailBlockStart + dateBlockStart;
   if (nameEnd > nameStart) {
     const rawName = bodyText.slice(nameStart, nameEnd)
       .replaceAll(/\s+/g, " ")

--- a/src/adapters/html-scraper/seven-hills-h3.ts
+++ b/src/adapters/html-scraper/seven-hills-h3.ts
@@ -27,16 +27,25 @@ import { fetchHTMLPage, chronoParseDate, parse12HourTime, decodeEntities } from 
  * #511 (Saturday specials via the current-trail slot).
  */
 
-/** "TRAIL #2005" */
-const TRAIL_NUMBER_RE = /TRAIL\s*#\s*(\d+)/i;
+/** "TRAIL #2005" (older layout) or "Trail 2028" (live layout as of #2663,
+ *  verified 2026-08-13 — the site dropped the "#"). The "#" is optional so
+ *  both shapes match. */
+const TRAIL_NUMBER_RE = /TRAIL\s*#?\s*(\d+)/i;
 /** Day names used for injecting a split before the date phrase. */
 const DATE_SPLIT_RE = /(Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday)/g;
 /** Known field labels on the 7H4 page that need a preceding newline so value regexes don't run past them. */
 const FIELD_LABEL_SPLIT_RE = /(When:|Start:|Hares?:|Beer\s*Meister:|Cost:|Shiggy\s*Level:|Special\s*Instructions:|On[\s-]*On)/g;
-/** "Saturday April 4, 2026 @ 2pm" — captures the leading date phrase. */
-const DATE_PHRASE_RE = /((?:Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday),?\s+(?:January|February|March|April|May|June|July|August|September|October|November|December)\s+\d{1,2},?\s+\d{4})/i;
-/** "@ 2pm" / "@ 2:30 PM" — minutes optional. Captured time is normalized into `HH:MM am/pm` before parsing. */
-const TIME_AT_RE = /@\s*(\d{1,2})(?::(\d{2}))?\s*(a\.?m\.?|p\.?m\.?)/i;
+/** "Saturday April 4, 2026" (older layout) or "August 12, 2026" (live layout
+ *  as of #2663, verified 2026-08-13 — the site dropped the leading
+ *  day-of-week). The day-name + comma prefix is optional so both shapes
+ *  match; only the month/day/year is captured either way. */
+const DATE_PHRASE_RE = /(?:(?:Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday),?\s+)?((?:January|February|March|April|May|June|July|August|September|October|November|December)\s+\d{1,2},?\s+\d{4})/i;
+/** "@ 2pm" (older layout) or "6:30p.m." with no "@" at all (live layout as
+ *  of #2663, verified 2026-08-13). The "@" is optional; the trailing
+ *  am/pm suffix is the real anchor so this stays safe against false
+ *  matches elsewhere in the body text. Minutes optional either way.
+ *  Captured time is normalized into `HH:MM am/pm` before parsing. */
+const TIME_AT_RE = /@?\s*(\d{1,2})(?::(\d{2}))?\s*(a\.?m\.?|p\.?m\.?)/i;
 /** "Hares: Frodo & Snatch" — up to the next line / label / EOD. */
 const HARES_RE = /Hares?:\s*([^\n]+)/i;
 /** "Start: 442 S Five Forks Road Monroe, VA" — up to the next line / label / EOD. */
@@ -70,13 +79,25 @@ export function parseSevenHillsPage(html: string): ParsedTrail | null {
   if (!trailMatch) return null;
   const runNumber = Number.parseInt(trailMatch[1], 10);
 
-  const dateMatch = DATE_PHRASE_RE.exec(bodyText);
-  if (!dateMatch) return null;
-  const date = chronoParseDate(dateMatch[1], "en-US", new Date(), { forwardDate: true });
+  // Search only the text AFTER "TRAIL #N" / "Trail N" for the date/time/
+  // hares/location fields. The page's "About Hashing" prose above the trail
+  // block contains the club's founding date ("began in Lynchburg, Virginia
+  // on June 21, 1992") with no leading day-of-week — once DATE_PHRASE_RE's
+  // day-name prefix became optional (#2663, to match the live "August 12,
+  // 2026" no-day-name layout), an unanchored search on the WHOLE body text
+  // matched that 1992 founding date instead of the actual upcoming trail
+  // date. Anchoring to after the trail number guarantees we only ever see
+  // the current trail's own field block.
+  const trailBlockStart = trailMatch.index + trailMatch[0].length;
+  const trailBlock = bodyText.slice(trailBlockStart);
+
+  const dateMatchInBlock = DATE_PHRASE_RE.exec(trailBlock);
+  if (!dateMatchInBlock) return null;
+  const date = chronoParseDate(dateMatchInBlock[1], "en-US", new Date(), { forwardDate: true });
   if (!date) return null;
 
   // parse12HourTime requires explicit minutes, so synthesize ":00" for the "2pm" short form.
-  const timeMatch = TIME_AT_RE.exec(bodyText);
+  const timeMatch = TIME_AT_RE.exec(trailBlock);
   let startTime: string | undefined;
   if (timeMatch) {
     const hour = timeMatch[1];
@@ -87,10 +108,10 @@ export function parseSevenHillsPage(html: string): ParsedTrail | null {
     startTime = parse12HourTime(`${hour}:${minutes} ${ampm}`);
   }
 
-  const haresMatch = HARES_RE.exec(bodyText);
+  const haresMatch = HARES_RE.exec(trailBlock);
   const hares = haresMatch?.[1]?.trim() || undefined;
 
-  const startMatch = START_RE.exec(bodyText);
+  const startMatch = START_RE.exec(trailBlock);
   const location = startMatch?.[1]?.trim() || undefined;
 
   // Trail name sits between "TRAIL #N" and the date phrase, decorated with emoji
@@ -100,8 +121,8 @@ export function parseSevenHillsPage(html: string): ParsedTrail | null {
   // phrase. Splitting at \n[0] is wrong: DATE_SPLIT_RE also injects \n before day
   // names, so a title like "Saturday Night Fever Trail" would be truncated.
   let title: string | undefined;
-  const nameStart = trailMatch.index + trailMatch[0].length;
-  const nameEnd = dateMatch.index;
+  const nameStart = trailBlockStart;
+  const nameEnd = trailBlockStart + dateMatchInBlock.index;
   if (nameEnd > nameStart) {
     const rawName = bodyText.slice(nameStart, nameEnd)
       .replaceAll(/\s+/g, " ")

--- a/src/adapters/html-scraper/swh3.test.ts
+++ b/src/adapters/html-scraper/swh3.test.ts
@@ -216,4 +216,31 @@ describe("SWH3Adapter.fetch — date fallback (#2667)", () => {
     expect(result.events).toHaveLength(0);
     expect(result.errors[0]).toContain("No date found in title");
   });
+
+  it("does not resolve a time-only When: field to the publish date (PR review finding)", async () => {
+    // A bare title + a "When:" field carrying ONLY a time ("2:30 pm", no
+    // date at all) would otherwise let chrono silently fill in the publish
+    // date as if it were the trail date. requireCertainDate on the
+    // chronoParseDate fallback must reject this and fail loud instead of
+    // emitting a wrong-but-plausible date.
+    const posts = [
+      {
+        id: 2,
+        date: "2026-04-07T14:34:53",
+        link: "https://swh3.wordpress.com/y/",
+        title: { rendered: "SWH3 Trail #9998" },
+        content: { rendered: "<p>When: 2:30 pm</p><p>Hares: Nobody</p>" },
+      },
+    ];
+    vi.mocked(safeFetch).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => posts,
+    } as unknown as Response);
+
+    const result = await new SWH3Adapter().fetch({} as Source);
+
+    expect(result.events).toHaveLength(0);
+    expect(result.errors[0]).toContain("No date found in title");
+  });
 });

--- a/src/adapters/html-scraper/swh3.test.ts
+++ b/src/adapters/html-scraper/swh3.test.ts
@@ -1,5 +1,9 @@
-import { describe, it, expect } from "vitest";
-import { parseSWH3Title, parseSWH3Body, cleanTrailingPunct } from "./swh3";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { parseSWH3Title, parseSWH3Body, cleanTrailingPunct, SWH3Adapter } from "./swh3";
+import { safeFetch } from "../safe-fetch";
+import type { Source } from "@/generated/prisma/client";
+
+vi.mock("../safe-fetch", () => ({ safeFetch: vi.fn() }));
 
 describe("cleanTrailingPunct (#1647)", () => {
   it("strips trailing dash from 'SWH3 #1792-'", () => {
@@ -145,5 +149,71 @@ describe("parseSWH3Body", () => {
     expect(result.startTime).toBeUndefined();
     expect(result.location).toBeUndefined();
     expect(result.hares).toBeUndefined();
+  });
+
+  it("captures the raw When: text as whenText (#2667 title-date fallback source)", () => {
+    const html = `<p>When: Saturday, April 11th</p><p>Meet: Noon, Pack off at 12:30</p>`;
+    const result = parseSWH3Body(html);
+    expect(result.whenText).toBe("Saturday, April 11th");
+  });
+});
+
+describe("SWH3Adapter.fetch — date fallback (#2667)", () => {
+  afterEach(() => vi.mocked(safeFetch).mockReset());
+
+  it("falls back to the body's When: field when the title has no date suffix", async () => {
+    // Real shape of https://swh3.wordpress.com/2026/04/07/swh3-trail-1786/ —
+    // title is bare "SWH3 Trail #1786", no date; only the body's "When:"
+    // field carries the trail date. Previously this failed the whole post.
+    const posts = [
+      {
+        id: 3798,
+        date: "2026-04-07T14:34:53",
+        link: "https://swh3.wordpress.com/2026/04/07/swh3-trail-1786/",
+        title: { rendered: "SWH3 Trail #1786" },
+        content: {
+          rendered:
+            "<p>What's da Word: Karen Trail: Volume VII</p>" +
+            "<p>Hares: Quick to Shoot and 50 Shades of Vanilla</p>" +
+            "<p>When: Saturday, April 11th</p>" +
+            "<p>Meet: Noon, Pack off at 12:30</p>" +
+            "<p>Where: 408 Sarazen Drive, Clayton</p>",
+        },
+      },
+    ];
+    vi.mocked(safeFetch).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => posts,
+    } as unknown as Response);
+
+    const result = await new SWH3Adapter().fetch({} as Source);
+
+    expect(result.errors).toEqual([]);
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0].date).toBe("2026-04-11");
+    expect(result.events[0].runNumber).toBe(1786);
+  });
+
+  it("still fails loud when neither the title nor the When: field has a date", async () => {
+    const posts = [
+      {
+        id: 1,
+        date: "2026-04-07T14:34:53",
+        link: "https://swh3.wordpress.com/x/",
+        title: { rendered: "SWH3 Trail #9999" },
+        content: { rendered: "<p>Hares: Nobody</p>" },
+      },
+    ];
+    vi.mocked(safeFetch).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => posts,
+    } as unknown as Response);
+
+    const result = await new SWH3Adapter().fetch({} as Source);
+
+    expect(result.events).toHaveLength(0);
+    expect(result.errors[0]).toContain("No date found in title");
   });
 });

--- a/src/adapters/html-scraper/swh3.ts
+++ b/src/adapters/html-scraper/swh3.ts
@@ -137,6 +137,12 @@ export function parseSWH3Time(timeText: string): string | undefined {
  */
 export function parseSWH3Body(html: string): {
   startTime?: string;
+  /** Raw text of the Time/When field, e.g. "Saturday, April 11th" — kept
+   *  alongside the parsed time so callers can fall back to it for the trail
+   *  DATE when the title itself carries none (#2667: "SWH3 Trail #1786"
+   *  posts have no date suffix in the title at all — only "When:" in the
+   *  body). */
+  whenText?: string;
   location?: string;
   hares?: string;
   trailName?: string;
@@ -152,6 +158,7 @@ export function parseSWH3Body(html: string): {
 
   // Time / When — extract pack-off/start time from field like "Meet at 2:00 for a 2:30 start"
   const timeMatch = text.match(new RegExp(`(?:Time|When)\\s*:\\s*(.+?)${stop}`, "i"));
+  const whenText = timeMatch ? timeMatch[1].trim() : undefined;
   const startTime = timeMatch ? parseSWH3Time(timeMatch[1]) : undefined;
 
   // Where / Start location
@@ -182,7 +189,7 @@ export function parseSWH3Body(html: string): {
   const onAfterMatch = text.match(/On[ -]After:\s*(.+?)(?=\n|$)/i);
   const onAfter = onAfterMatch ? onAfterMatch[1].trim() : undefined;
 
-  return { startTime, location, hares, trailName, onAfter };
+  return { startTime, whenText, location, hares, trailName, onAfter };
 }
 
 /** Process a single WordPress.com post into a RawEventData. */
@@ -197,8 +204,16 @@ function processPost(
   const titleFields = parseSWH3Title(titleText, post.date);
   const bodyFields = parseSWH3Body(post.content.rendered);
 
-  // Event date comes from the title, NOT the publish date
-  const date = titleFields.date;
+  // Event date normally comes from the title, NOT the publish date. Some
+  // posts (#2667 — "SWH3 Trail #1786") carry no date suffix in the title at
+  // all, only a "When: Saturday, April 11th" field in the body — fall back
+  // to parsing that with the same publish-date-anchored chrono call the
+  // title path uses, rather than failing the whole post.
+  const date =
+    titleFields.date ??
+    (bodyFields.whenText
+      ? chronoParseDate(bodyFields.whenText, "en-US", new Date(post.date)) ?? undefined
+      : undefined);
   if (!date) {
     const msg = `No date found in title: "${titleText}"`;
     errors.push(msg);
@@ -207,7 +222,7 @@ function processPost(
       section: "post",
       field: "date",
       error: msg,
-      rawText: `Title: ${titleText}`.slice(0, 2000),
+      rawText: `Title: ${titleText}${bodyFields.whenText ? ` | When: ${bodyFields.whenText}` : ""}`.slice(0, 2000),
     });
     return null;
   }

--- a/src/adapters/html-scraper/swh3.ts
+++ b/src/adapters/html-scraper/swh3.ts
@@ -209,20 +209,30 @@ function processPost(
   // all, only a "When: Saturday, April 11th" field in the body — fall back
   // to parsing that with the same publish-date-anchored chrono call the
   // title path uses, rather than failing the whole post.
+  //
+  // requireCertainDate guards against a real chrono footgun (PR review
+  // finding): a post whose "When:"/"Time:" field is time-only ("2:30 pm",
+  // no date at all) would otherwise have chrono silently resolve day/month
+  // from the publish-date reference and report the PUBLISH day as if it
+  // were the trail date — a wrong-but-plausible-looking date is worse than
+  // correctly falling through to "no parseable date".
   const date =
     titleFields.date ??
     (bodyFields.whenText
-      ? chronoParseDate(bodyFields.whenText, "en-US", new Date(post.date)) ?? undefined
+      ? chronoParseDate(bodyFields.whenText, "en-US", new Date(post.date), {
+          requireCertainDate: true,
+        }) ?? undefined
       : undefined);
   if (!date) {
     const msg = `No date found in title: "${titleText}"`;
     errors.push(msg);
+    const whenSuffix = bodyFields.whenText ? ` | When: ${bodyFields.whenText}` : "";
     (errorDetails.parse ??= []).push({
       row: index,
       section: "post",
       field: "date",
       error: msg,
-      rawText: `Title: ${titleText}${bodyFields.whenText ? ` | When: ${bodyFields.whenText}` : ""}`.slice(0, 2000),
+      rawText: `Title: ${titleText}${whenSuffix}`.slice(0, 2000),
     });
     return null;
   }

--- a/src/adapters/utils.test.ts
+++ b/src/adapters/utils.test.ts
@@ -763,6 +763,36 @@ describe("chronoParseDate", () => {
     const result = chronoParseDate("5 May 226", "en-GB");
     expect(result).toMatch(/^20\d{2}-05-05$/);
   });
+
+  // requireCertainDate (PR #2674 review finding, SWH3 date-fallback footgun)
+  describe("requireCertainDate option", () => {
+    const ref = new Date(Date.UTC(2026, 6, 6, 11, 19, 21)); // July 6, 2026
+
+    it("without the flag, a time-only string silently resolves to the reference date", () => {
+      // This is the existing/default behavior every other caller relies on
+      // (e.g. year-less "March 14" titles legitimately want the reference
+      // year filled in) — documenting it here so the opt-in flag's value is
+      // clear by contrast.
+      expect(chronoParseDate("2:30 pm", "en-US", ref)).toBe("2026-07-06");
+    });
+
+    it("with the flag, a time-only string (no day/month in the text) returns null", () => {
+      expect(chronoParseDate("2:30 pm", "en-US", ref, { requireCertainDate: true })).toBeNull();
+      expect(chronoParseDate("Noon", "en-US", ref, { requireCertainDate: true })).toBeNull();
+    });
+
+    it("with the flag, a real date+time string still resolves normally", () => {
+      expect(
+        chronoParseDate("Saturday, April 11th", "en-US", ref, { requireCertainDate: true }),
+      ).toBe("2026-04-11");
+    });
+
+    it("with the flag, a year-less month/day string still resolves (day+month are certain; only year is implied)", () => {
+      expect(chronoParseDate("March 14", "en-US", ref, { requireCertainDate: true })).toBe(
+        "2026-03-14",
+      );
+    });
+  });
 });
 
 describe("extractAddressWithAi", () => {

--- a/src/adapters/utils.ts
+++ b/src/adapters/utils.ts
@@ -575,7 +575,23 @@ export function chronoParseDate(
   text: string,
   locale: DateLocale = "en-US",
   referenceDate?: Date,
-  options?: { forwardDate?: boolean },
+  options?: {
+    forwardDate?: boolean;
+    /**
+     * Reject a parse whose day/month were only IMPLIED from the reference
+     * date rather than explicitly present in `text` — e.g. chrono parses a
+     * bare time-only string like "2:30 pm" as "today [referenceDate] at
+     * 2:30pm", silently returning the reference date with no date signal in
+     * the source text at all. Callers that fall back to a secondary field
+     * (a body "When:"/"Time:" label used as a date backstop when the primary
+     * source has none) should set this so a time-only value correctly
+     * reports "no date" instead of masquerading as a real one. Defaults to
+     * false to preserve existing behavior for the many callers that
+     * legitimately rely on year/month defaulting from the reference date
+     * (e.g. year-less "March 14" titles).
+     */
+    requireCertainDate?: boolean;
+  },
 ): string | null {
   // Fast-path: "D[D] MMM YY[YY]" with space or hyphen separators. Bypasses
   // a chrono-node bug where "5 May 26" becomes 2026-05-26 instead of
@@ -605,6 +621,10 @@ export function chronoParseDate(
   const day = parsed.get("day");
 
   if (year == null || month == null || day == null) return null;
+
+  if (options?.requireCertainDate && (!parsed.isCertain("day") || !parsed.isCertain("month"))) {
+    return null;
+  }
 
   return `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
 }

--- a/src/adapters/wordpress-api.test.ts
+++ b/src/adapters/wordpress-api.test.ts
@@ -3,6 +3,7 @@ import {
   fetchAllWordPressPosts,
   fetchWordPressComPosts,
   fetchWordPressPosts,
+  fetchWordPressRunPosts,
 } from "./wordpress-api";
 
 describe("fetchWordPressPosts", () => {
@@ -236,6 +237,93 @@ describe("fetchWordPressPosts", () => {
     );
 
     await fetchWordPressPosts("https://example.com/", 5);
+
+    const calledUrl = vi.mocked(fetch).mock.calls[0][0] as string;
+    expect(calledUrl).toContain("per_page=5");
+  });
+});
+
+// Extracted from the near-identical error-shaping block SonarCloud flagged
+// as duplicated between cah3.ts and klj-h3.ts (#2668 PR review) — see the
+// helper's own docstring for the full history.
+describe("fetchWordPressRunPosts", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns ok:true with the posts on success", async () => {
+    const apiResponse = [
+      {
+        title: { rendered: "Run 534: Songkran" },
+        content: { rendered: "<p>Hare: Someone</p>" },
+        link: "https://cah3.net/run-534/",
+        date: "2026-04-10T09:00:00",
+      },
+    ];
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }) as never,
+    );
+
+    const result = await fetchWordPressRunPosts("https://cah3.net", {
+      noPostsMessage: "no posts",
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.posts).toHaveLength(1);
+      expect(result.fetchDurationMs).toBeDefined();
+    }
+  });
+
+  it("returns ok:false with a ready-to-return ScrapeResult when zero posts come back", async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify([]), { status: 200 }) as never,
+    );
+
+    const result = await fetchWordPressRunPosts("https://cah3.net", {
+      noPostsMessage: "CAH3 WordPress API returned no posts",
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.result.events).toEqual([]);
+      expect(result.result.errors).toEqual(["CAH3 WordPress API returned no posts"]);
+      expect(result.result.errorDetails?.fetch?.[0]).toMatchObject({
+        url: "https://cah3.net",
+        message: "CAH3 WordPress API returned no posts",
+      });
+    }
+  });
+
+  it("returns ok:false using the upstream error message when the fetch itself fails", async () => {
+    vi.mocked(fetch).mockRejectedValue(new Error("network down"));
+
+    const result = await fetchWordPressRunPosts("https://cah3.net", {
+      noPostsMessage: "fallback message",
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.result.errors[0]).toContain("WordPress API fetch error");
+    }
+  });
+
+  it("respects the perPage option", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify([]), { status: 200 }) as never,
+    );
+
+    await fetchWordPressRunPosts("https://cah3.net", {
+      noPostsMessage: "no posts",
+      perPage: 5,
+    });
 
     const calledUrl = vi.mocked(fetch).mock.calls[0][0] as string;
     expect(calledUrl).toContain("per_page=5");

--- a/src/adapters/wordpress-api.ts
+++ b/src/adapters/wordpress-api.ts
@@ -16,6 +16,7 @@
 import he from "he";
 import { buildUrlVariantCandidates } from "@/adapters/url-variants";
 import { safeFetch } from "./safe-fetch";
+import type { ScrapeResult, ErrorDetails } from "./types";
 
 const WP_USER_AGENT = "HashTracks/1.0 (event aggregator; +https://hashtracks.com)";
 
@@ -290,6 +291,43 @@ export async function fetchWordPressPosts(
     error: lastError ?? { message: "WordPress API fetch failed" },
     fetchDurationMs: Date.now() - fetchStart,
   };
+}
+
+/** Result of {@link fetchWordPressRunPosts} — a discriminated union so
+ *  callers can `if (!result.ok) return result.result;` and move on. */
+export type WordPressRunPostsResult =
+  | { ok: true; posts: WordPressPost[]; fetchDurationMs?: number }
+  | { ok: false; result: ScrapeResult };
+
+/**
+ * Fetch the latest N posts for a "one WordPress post per run" adapter
+ * (CAH3, KLJ H3, and others), pre-packaging the "fetch failed / zero posts"
+ * case into the standard `ScrapeResult` early-return shape every one of
+ * those adapters otherwise duplicates near-verbatim: call
+ * `fetchWordPressPosts`, check `wpResult.error || wpResult.posts.length ===
+ * 0`, build a single-element `errorDetails.fetch` array, and return
+ * `{ events: [], errors: [message], errorDetails }`.
+ *
+ * SonarCloud flagged this exact block as duplicated between cah3.ts and
+ * klj-h3.ts during #2668 PR review (both call `fetchWordPressPosts(baseUrl,
+ * 20)` and reproduce the same ~15-line error-shaping block). Extracting it
+ * here means new/edited adapters no longer reproduce it inline — existing
+ * callers with the older inline shape (dch4.ts, ewh3.ts, etc.) are left
+ * alone since they weren't touched by this change.
+ */
+export async function fetchWordPressRunPosts(
+  siteUrl: string,
+  options: { perPage?: number; noPostsMessage: string },
+): Promise<WordPressRunPostsResult> {
+  const wpResult = await fetchWordPressPosts(siteUrl, options.perPage ?? 20);
+  if (wpResult.error || wpResult.posts.length === 0) {
+    const message = wpResult.error?.message ?? options.noPostsMessage;
+    const errorDetails: ErrorDetails = {
+      fetch: [{ url: siteUrl, message, status: wpResult.error?.status }],
+    };
+    return { ok: false, result: { events: [], errors: [message], errorDetails } };
+  }
+  return { ok: true, posts: wpResult.posts, fetchDurationMs: wpResult.fetchDurationMs };
 }
 
 /**


### PR DESCRIPTION
## Summary

Ten sources hit 4 consecutive scrape failures (#2660-#2669). Each had an independent root cause — verified live against the production URL/API per `.claude/rules/live-verification.md` before any fix, per the workstream brief. Result: 7 code fixes, 1 infra fix (no code change), 1 seed disable + companion migration, 1 self-healed (already fixed on `main`, alert was stale), 1 confirmed transient (no action).

## Fixed (code changes, live-verified)

### #2661 Philly H3 Website — `src/adapters/html-scraper/hashphilly.ts`
The `/nexthash/` page publishes `Date: TBD` between hares stepping up for the next trail — the site working correctly with nothing scheduled yet, not a scraper bug. The adapter treated any unparseable date as a hard failure. Now recognizes common placeholders (TBD/TBA/N-A/"coming soon") and succeeds with zero events instead of erroring.
- **Live evidence:** `events=0, errors=[]` (page currently shows `Date: TBD`)

### #2663 Seven Hills H3 Google Sites — `src/adapters/html-scraper/seven-hills-h3.ts`
The live page changed three field shapes simultaneously: `"TRAIL #2005"` → `"Trail 2028"` (no `#`), `"Saturday April 4, 2026"` → `"August 12, 2026"` (no leading day-of-week), `"@ 2pm"` → `"6:30p.m."` (no `@`). Made all three regex anchors optional — which introduced a regression caught during live verification: once the date regex's day-name prefix became optional, an unanchored search over the whole page matched the club's 1992 founding date in the "About Hashing" prose (no day name attached, appears earlier in body order) instead of the actual trail date. Fixed by scoping the date/time/hares/location search to the text *after* the `TRAIL #N` / `Trail N` match instead of the whole page body.
- **Live evidence:** `events=1, errors=[]`, sample:
  ```json
  {"date":"2026-08-12","runNumber":2028,"hares":"UTB & Mystery Hare","location":"Jojos Pizza 1400 Lakeside Drive Lynchburg VA 24501","startTime":"18:30"}
  ```

### #2665 Riyadh H3 Supabase API — `src/adapters/html-scraper/riyadh-h3.ts`
Diagnosis assumed the anon JWT rotated. Investigation showed it did **not** — the current key still authenticates fine against every other table/column (`faq_items`, `site_banners`, `hikes.id/date/title/location/gathering_time/description` all 200). Column-by-column probing isolated the real cause: the site owner revoked the anon role's column-level SELECT grant on exactly `hikes.location_gps` and `hikes.map_link` (both 401 "permission denied for table hikes" in isolation). PostgREST fails the *whole* request when any requested column lacks a grant. Dropped both from the shared `HIKES_SELECT` (also used by the history backfill via the same constant); `mapHikeRow` already treats them as optional and falls back to geocoding.
- **Live evidence:** `events=1, errors=[]`, sample:
  ```json
  {"date":"2026-08-14","title":"Celebration 2500 Run","runNumber":2500,"startTime":"15:00","location":"Ammairyah","description":"The Big Event in Fossil mountains..."}
  ```

### #2666 Hash House Horrors Hareline — `src/adapters/html-scraper/hash-horrors.ts`
Traced the exact 9 dropped lines. Two distinct permanent causes, neither a parser regression:
1. **False match:** `"...Singapore 099115 – Bottom of Mount Faber..."` — the trailing 4 digits of a 6-digit postal code satisfy the run-line tokenizer's digits+dash+word shape. Fixed with a `(?<!\d)` lookbehind.
2. **8 genuinely dateless archive rows** (run #526-628, from the 1994-2004 era) — the kennel's own `/hareline` page has never carried a month/day for these; the row is just `"<run#> – <hares> – <location>"`. Added an explicit, documented allowlist so these skip silently (tracked via a new `skippedKnownGaps` diagnostic) instead of tripping drift alerts every scrape. A *new*, unlisted dateless row still counts as drift.
- **Live evidence:** `events=293, errors=[]`, date range `1993-08-08 .. 2027-08-09`, sample:
  ```json
  {"date":"2026-04-19","startTime":"16:30","runNumber":1014,"title":"Hash Horrors 1014","hares":"Brown, Prue and Sukal families"}
  ```

### #2667 SWH3 Trail Announcements — `src/adapters/html-scraper/swh3.ts`
`"SWH3 Trail #1786"` publishes no date suffix in the title at all — only `"When: Saturday, April 11th"` in the body. The title parser was the sole date source, so this shape hard-failed. `parseSWH3Body` now also returns the raw `When:` field text; `processPost` falls back to `chronoParseDate` on it (anchored to publish date) before giving up.
- **Live evidence:** `events=20, errors=[]`, date range `2026-03-14 .. 2026-08-16`, sample:
  ```json
  {"date":"2026-08-16","startTime":"14:30","runNumber":1805,"title":"SWH3 #1805, Sunday, Aug 16","hares":"In My Otter Ear and Two Buck Duck","location":"Easley Elementary School"}
  ```

### #2668 Cha-Am H3 Website — `src/adapters/html-scraper/cah3.ts`
cah3.net redesigned its "Run NNN" posts mid-2026 onto a generic "RUN DIRECTIONS / SPECIAL NOTE FROM THE HARES / ON AFTER DIRECTIONS" template with no date field anywhere — confirmed against the raw WP REST payload (no title date, no body date, no ACF/meta date). The site's own `/hareline/` page now points hares at a Facebook Events page for scheduling instead. This was already a documented, by-design partial-parse source (seed comment: *"~20% of posts whose titles do carry dates ... rejects the rest"*, paired with a `STATIC_SCHEDULE` sibling for the recurring biweekly baseline) — the redesign just pushed the miss rate up, tripping the alert every scrape even though nothing regressed. No-date skips now flow to `diagnosticContext` (`skippedNoDate`) instead of `errors`, so partial skips no longer drive `FAILED` as long as at least one post still yields a dated event. Escalates to a hard error only if **every** post in a scrape lacks a date.
- **Live evidence:** `events=2, errors=[]`, date range `2026-01-19 .. 2026-04-10` (run #534 "Songkran Outstation APR 10 & 11" and run #529)

## Fixed (infrastructure, no code change)

### #2660 Atlanta Hash Board
Root cause: the NAS `proxy-relay-vpn` container (gluetun-routed egress for OVH-firewalled `board.atlantahash.com`) had died on 2026-07-11 — exactly matching Atlanta's last-success timestamp — and stayed down (`Exited (137) 4 weeks ago`). Restarted it (`docker compose up -d proxy-relay-vpn`); confirmed end-to-end via a direct `POST /proxy` call and then a full adapter run. No adapter/seed changes — `config.egress: "vpn"` was already correct.
- **Live evidence:** `events=40, errors=[]`, date range `2026-05-16 .. 2026-08-10` across all 9 forums (ah4, ph3-atl, bsh3, sobh3, whh3, mlh4, duffh3, sluth3, soco-h3)

## Disabled with reason

### #2662 Top End Hash Hareline — `prisma/seed-data/sources.ts` + migration `20260813120000_disable_topend_h3_hareline`
Every URL under `topendhash.com` (root and the iCal export path) now resolves to a GoDaddy "Great things are coming soon" domain-parking page, not a 404 — the whole site was torn down. Confirmed via the official HHH club directory (hhh.asn.au) that the club is still active (Thursdays 1800), but its only other online presence is a **private Facebook Group** (`facebook.com/groups/TopEndHash`), which the `FACEBOOK_HOSTED_EVENTS` adapter cannot reach (public Pages' `/upcoming_hosted_events` only — Groups require login). No replacement source exists, so this is `enabled: false` with a companion migration (Vercel runs `migrate deploy`, never `db seed`).

## Self-healed — no action needed

### #2669 BAH3 iCal Feed
Already fixed on `main` over a month before this alert fired (commit `d5530185`, 2026-07-09): the source row was disabled with the comment *"all-in-one-event-calendar plugin gone, endpoint returns HTML"* and replaced by a healthy `Baltimore Annapolis GCal` source (`SUCCESS, events=83` on every recent scrape). The GitHub issue appears to have been filed from a stale/undismissed Alert row predating the fix. No changes made — flagging so the issue can be closed as already-resolved.

## Confirmed transient — no action taken

### #2664 Sydney H3 Hareline
Live-rechecked before touching anything, per the brief's caution. First check returned `HTTP 500`; a later check returned `HTTP 200` but with the site serving a raw Apache/LiteSpeed **directory listing** (`Index of /`, exposing `wp-config.php`, `error_log`, etc.) instead of rendered WordPress content — `index.php` isn't bootstrapping. This flapped between two different failure modes within the same session, confirming genuine upstream instability, not a parser bug. The adapter already fails loud correctly on this (`"Sydney H3 (sh3.link) scraper parsed 0 runs — possible WordPress format drift"` — 0 events, not a false success), so no code change was made. Recommend re-checking if the alert persists after the site owner's WordPress install stabilizes.

## Not completed / blocked

None of the ten required a Vercel env var change in the end — the Riyadh H3 fix turned out to be a query-shape issue, not a key rotation, so `RIYADH_H3_SUPABASE_ANON_KEY` does not need updating in Vercel.

## Verification

- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors, 22 pre-existing warnings (all in unrelated files, none touched by this PR)
- `npm test` — 340 files / 10010 tests passed, 0 failures
- Every fixed/verified source re-checked against its live production URL immediately before this PR was updated

## Ordering note

PR #2659 (hashnyc HTML→iCal cutover, touching `src/adapters/ical/adapter.test.ts` and `prisma/seed-data/sources.ts`) merged mid-session. This branch was rebased cleanly onto its head before the Top End `sources.ts` edit; no conflicts.

Closes #2660
Closes #2661
Closes #2662
Closes #2663
Closes #2665
Closes #2666
Closes #2667
Closes #2668
Closes #2669

🤖 Generated with [Claude Code](https://claude.com/claude-code)
