### PR TITLE
fix(kennels): profile metadata sweep — quick-win bundle (#2649, #2644, #2633, #2627, #2617, #2613, #2610, #2608, #2578, #2512, #2308)

### DIFF
--- a/prisma/migrations/20260813120000_profiles_audit_quickwin_bundle_2649_2308/migration.sql
+++ b/prisma/migrations/20260813120000_profiles_audit_quickwin_bundle_2649_2308/migration.sql
@@ -1,0 +1,110 @@
+-- Kennel profile metadata sweep (Quick Win bundle): #2649, #2644, #2633, #2627,
+-- #2617, #2613, #2610, #2608, #2578, #2512, #2308. (Companion to the seed-data
+-- edits in prisma/seed-data/kennels.ts.)
+--
+-- Vercel builds run `prisma migrate deploy && next build` and never
+-- `prisma db seed`, so seed-only additions do NOT reach prod on deploy. Apply
+-- them here so the closed audit issues are actually satisfied in prod (same
+-- approach as the earlier profile sweeps: 20260626120000, 20260706120000,
+-- 20260707120000).
+--
+-- Null-fills use COALESCE and a guard so only genuinely empty columns are
+-- written — never stomps an admin edit; re-run touches 0 rows.
+-- Corrections (#2512, #2308) use an explicit UPDATE because they replace a
+-- wrong/stale value rather than filling an empty one — see per-block notes.
+-- `updatedAt` is `timestamp without time zone`, so stamp with UTC wall-clock.
+--
+-- #2516 (Southern Comfort H3) is intentionally NOT included — the issue itself
+-- reports that no field is verifiable without a live source; nothing to apply.
+
+BEGIN;
+
+-- #2649 Queens (QBK) — description/schedule-notes + website (hashnyc.com umbrella)
+UPDATE "Kennel"
+SET "website" = COALESCE("website", 'https://hashnyc.com'),
+    "scheduleNotes" = COALESCE("scheduleNotes", 'Random days, random times.'),
+    "description" = COALESCE("description", 'Queens Hash House Harriers — Starts near public transit in Queens — Random days, random times.'),
+    "updatedAt" = NOW() AT TIME ZONE 'UTC'
+WHERE "kennelCode" = 'qbk'
+  AND (NULLIF(BTRIM("website"), '') IS NULL
+    OR NULLIF(BTRIM("scheduleNotes"), '') IS NULL
+    OR NULLIF(BTRIM("description"), '') IS NULL);
+
+-- #2644 Wasatch H3 — Utah H3 umbrella Facebook group (foundedYear NOT set — source
+-- only says "over 30 years", no exact year to assert)
+UPDATE "Kennel"
+SET "facebookUrl" = COALESCE("facebookUrl", 'https://facebook.com/groups/UtahH3'),
+    "updatedAt" = NOW() AT TIME ZONE 'UTC'
+WHERE "kennelCode" = 'wasatch-h3' AND NULLIF(BTRIM("facebookUrl"), '') IS NULL;
+
+-- #2633 WSH3 — organizer contact email (lower confidence: rotates yearly; most
+-- recent known value from the 2025 SOEX HashRego event page)
+UPDATE "Kennel"
+SET "contactEmail" = COALESCE("contactEmail", 'wileyzachary2@gmail.com'), "updatedAt" = NOW() AT TIME ZONE 'UTC'
+WHERE "kennelCode" = 'wsh3' AND NULLIF(BTRIM("contactEmail"), '') IS NULL;
+
+-- #2627 TNTH3 — founded year (edinburghh3.com/tnt-history.html: first trail 11 Apr 1984)
+UPDATE "Kennel"
+SET "foundedYear" = COALESCE("foundedYear", 1984), "updatedAt" = NOW() AT TIME ZONE 'UTC'
+WHERE "kennelCode" = 'tnth3' AND "foundedYear" IS NULL;
+
+-- #2617 West London H3 — hash cash + Facebook group + contact email + description
+UPDATE "Kennel"
+SET "hashCash" = COALESCE("hashCash", '£2 per run (£35/year membership)'),
+    "facebookUrl" = COALESCE("facebookUrl", 'https://www.facebook.com/groups/1822849584637512'),
+    "contactEmail" = COALESCE("contactEmail", 'westlondonh3@gmail.com'),
+    "description" = COALESCE("description", 'A highly inclusive group with a diverse and cosmopolitan following, hashing all-year-round every Thursday. Meet at a pub within walking distance of a tube/mainline station for a 4–5 mile, ~1 hour P-trail of chalked Ps from the station.'),
+    "updatedAt" = NOW() AT TIME ZONE 'UTC'
+WHERE "kennelCode" = 'wlh3'
+  AND (NULLIF(BTRIM("hashCash"), '') IS NULL
+    OR NULLIF(BTRIM("facebookUrl"), '') IS NULL
+    OR NULLIF(BTRIM("contactEmail"), '') IS NULL
+    OR NULLIF(BTRIM("description"), '') IS NULL);
+
+-- #2613 Warsaw H3 — contact email (mailto in site footer)
+UPDATE "Kennel"
+SET "contactEmail" = COALESCE("contactEmail", 'WarsawH3@gmail.com'), "updatedAt" = NOW() AT TIME ZONE 'UTC'
+WHERE "kennelCode" = 'warsaw-h3' AND NULLIF(BTRIM("contactEmail"), '') IS NULL;
+
+-- #2610 W3H3 — founded year (Hareline sheet Hash #1 "Inaugural Hash!!!" 06/12/2019)
+-- + hareraiser contact email (Hareline sheet header)
+UPDATE "Kennel"
+SET "foundedYear" = COALESCE("foundedYear", 2019),
+    "contactEmail" = COALESCE("contactEmail", 'w3h3hareraiser@gmail.com'),
+    "updatedAt" = NOW() AT TIME ZONE 'UTC'
+WHERE "kennelCode" = 'w3h3'
+  AND ("foundedYear" IS NULL OR NULLIF(BTRIM("contactEmail"), '') IS NULL);
+
+-- #2608 Toulouse H3 — contact email (toulousehash.com/hash-contacts/)
+UPDATE "Kennel"
+SET "contactEmail" = COALESCE("contactEmail", 'contact@toulousehash.com'), "updatedAt" = NOW() AT TIME ZONE 'UTC'
+WHERE "kennelCode" = 'toulouse-h3' AND NULLIF(BTRIM("contactEmail"), '') IS NULL;
+
+-- #2578 Fengyuan H3 (FISHHH) — Facebook Page (confirmed live)
+UPDATE "Kennel"
+SET "facebookUrl" = COALESCE("facebookUrl", 'https://www.facebook.com/TWFISH3'), "updatedAt" = NOW() AT TIME ZONE 'UTC'
+WHERE "kennelCode" = 'fishhh' AND NULLIF(BTRIM("facebookUrl"), '') IS NULL;
+
+-- #2512 SLUT H3 — CORRECTION, not a null-fill. The kennel page shows "Since
+-- first known run in 2025" (derived from the earliest ingested event, itself
+-- an artifact of a too-narrow scrape window). Atlanta Hash Board's oldest SLUT
+-- topic is #247 (Jun 2023); the run numbering implies real history predates
+-- the forum. Set foundedYear to the verified floor (2023) so the kennel page
+-- stops showing the wrong "2025" hint (the "Since first known run in <year>"
+-- copy only renders when foundedYear is NULL). Guarded to correct anything
+-- currently NULL or later than the verified floor, without clobbering a more
+-- accurate value a human may set later.
+UPDATE "Kennel"
+SET "foundedYear" = 2023, "updatedAt" = NOW() AT TIME ZONE 'UTC'
+WHERE "kennelCode" = 'sluth3' AND ("foundedYear" IS NULL OR "foundedYear" > 2023);
+
+-- #2308 SL,UT Discovery — CORRECTION, not a null-fill. The stored slug
+-- "sl,ut-discovery" contains a literal comma, which 404s the `/kennels/<slug>`
+-- route (Next.js path-segment matching never resolves it, encoded or not).
+-- toSlug() already strips commas correctly (src/lib/kennel-utils.ts) — this
+-- row predates that fix. Re-slugify to the clean form.
+UPDATE "Kennel"
+SET "slug" = 'sl-ut-discovery', "updatedAt" = NOW() AT TIME ZONE 'UTC'
+WHERE "kennelCode" = 'slut-h3' AND "slug" != 'sl-ut-discovery';
+
+COMMIT;

--- a/prisma/seed-data/kennels.ts
+++ b/prisma/seed-data/kennels.ts
@@ -136,6 +136,9 @@ export const KENNELS: KennelSeed[] = [
     {
       kennelCode: "qbk", shortName: "Queens", fullName: "Queens Black Knights Hash House Harriers", region: "New York City, NY",
       logoUrl: "/kennel-logos/qbk.png",
+      website: "https://hashnyc.com", // #2649: umbrella site (already the tracked source); QBK has no dedicated site
+      scheduleNotes: "Random days, random times.", // #2649: explicitly no fixed weekly schedule per hashnyc.com
+      description: "Queens Hash House Harriers — Starts near public transit in Queens — Random days, random times.", // #2649
     },
     { kennelCode: "si", shortName: "SI", fullName: "Staten Island Hash House Harriers", region: "New York City, NY" },
     { kennelCode: "columbia", shortName: "Columbia", fullName: "Columbia Hash House Harriers", region: "New York City, NY" },
@@ -593,6 +596,8 @@ export const KENNELS: KennelSeed[] = [
       kennelCode: "w3h3", shortName: "W3H3", fullName: "Wild and Wonderful Wednesday Hash House Harriers", region: "Jefferson County, WV",
       website: "https://sites.google.com/view/w3h3",
       facebookUrl: "https://www.facebook.com/groups/273947756839837/",
+      foundedYear: 2019, // #2610: W3H3 Hareline sheet, Hash #1 "W3H3 Inaugural Hash!!!" 06/12/2019
+      contactEmail: "w3h3hareraiser@gmail.com", // #2610: hareraiser contact, W3H3 Hareline sheet header
       scheduleDayOfWeek: "Wednesday", scheduleTime: "6:09 PM", scheduleFrequency: "Weekly",
       description: "Weekly Wednesday 6:09 PM hash in Jefferson County, West Virginia (Harpers Ferry area).",
       latitude: 39.32, longitude: -77.87,
@@ -1058,6 +1063,10 @@ export const KENNELS: KennelSeed[] = [
       website: "https://westlondonhash.com",
       logoUrl: "https://westlondonhash.com/wp-content/uploads/2013/07/west-london-hash-harriers-logo.png",
       scheduleDayOfWeek: "Thursday", scheduleTime: "7:00 PM", scheduleFrequency: "Weekly",
+      hashCash: "£2 per run (£35/year membership)", // #2617: westlondonhash.com/about/
+      facebookUrl: "https://www.facebook.com/groups/1822849584637512", // #2617: closed FB group
+      contactEmail: "westlondonh3@gmail.com", // #2617: weekly runs mailing list
+      description: "A highly inclusive group with a diverse and cosmopolitan following, hashing all-year-round every Thursday. Meet at a pub within walking distance of a tube/mainline station for a 4–5 mile, ~1 hour P-trail of chalked Ps from the station.", // #2617
     },
     {
       kennelCode: "barnesh3", shortName: "BarnesH3", fullName: "Barnes Hash House Harriers", region: "London", country: "UK",
@@ -1148,6 +1157,7 @@ export const KENNELS: KennelSeed[] = [
       latitude: 57.1497, longitude: -2.0943 },
     { kennelCode: "tnth3", shortName: "The New Town Hash", fullName: "The New Town Hash (Big Bang Hash)",
       region: "Edinburgh", country: "UK", logoUrl: "/kennel-logos/tnth3.png",
+      foundedYear: 1984, // #2627: edinburghh3.com/tnt-history.html — first trail 11 Apr 1984
       scheduleDayOfWeek: "Wednesday", scheduleTime: "6:30 PM", scheduleFrequency: "Weekly",
       scheduleNotes: "Weekly Wednesday-evening Edinburgh trail. Also known as the Big Bang Hash.",
       hashCash: "£1", description: "Edinburgh's weekly Wednesday-evening New Town / Big Bang hash.",
@@ -2333,6 +2343,10 @@ export const KENNELS: KennelSeed[] = [
       kennelCode: "sluth3", shortName: "SLUT H3", fullName: "Short Lazy Urban Thursday H3", region: "Atlanta, GA",
       scheduleFrequency: "Monthly", scheduleNotes: "1st Thursday, 7:00 PM.",
       hashCash: "$10", // $10 all-inclusive (beer, food, trail) — consistent across Atlanta Hash Board posts
+      // #2512: corrects wrong "Since first known run in 2025" display — Atlanta Hash Board's
+      // oldest SLUT topic is #247 (Jun 2023); run numbering implies the kennel predates the
+      // forum itself, so 2023 is a verified floor, not the exact founding year.
+      foundedYear: 2023,
       description: "Monthly Thursday evening urban trail in Atlanta.",
     },
     {
@@ -3521,6 +3535,7 @@ export const KENNELS: KennelSeed[] = [
       // No explicit slug — toSlug("Fengyuan H3") = "fengyuan-h3". The HC acronym "FISHHH" is
       // kept as an alias (Bandung "BHHH2" → "Bandung H3" precedent). Taiwan's 5th metro (Taichung).
       region: "Taichung", country: "Taiwan",
+      facebookUrl: "https://www.facebook.com/TWFISH3", // #2578: active FB Page, confirmed live
       foundedYear: 2022, // verified: HC run #1 = 2022-08-07
       scheduleDayOfWeek: "Sunday", // nominal ("Irregular Sunday"); actual days/times genuinely vary
       scheduleFrequency: "Irregular",
@@ -4187,6 +4202,7 @@ export const KENNELS: KennelSeed[] = [
       kennelCode: "wsh3", shortName: "Wandering Soul H3", fullName: "Wandering Soul Hash House Harriers", region: "Birmingham, AL",
       scheduleFrequency: "Annually",
       scheduleNotes: "Annual hash campout (SOEX) held each June. No regular weekly trail schedule.",
+      contactEmail: "wileyzachary2@gmail.com", // #2633: organizer-tied, rotates yearly (2025 SOEX contact) — lower confidence
       description: "Birmingham, Alabama hash kennel. Best known for hosting the annual SOEX (Southern Excursion) hash campout.",
       latitude: 33.52, longitude: -86.81,
     },
@@ -5368,6 +5384,7 @@ export const KENNELS: KennelSeed[] = [
       kennelCode: "wasatch-h3", shortName: "Wasatch H3", fullName: "Wasatch Hash House Harriers",
       region: "Salt Lake City, UT",
       website: "https://www.whoremanh3.com",
+      facebookUrl: "https://facebook.com/groups/UtahH3", // #2644: Utah H3 umbrella group, linked from whoremanh3.com/utah-kennels/
       scheduleDayOfWeek: "Saturday", scheduleFrequency: "Biweekly",
       scheduleTime: "10:45 AM",
       scheduleRules: [{ rrule: "FREQ=WEEKLY;INTERVAL=2;BYDAY=SA", anchorDate: "2026-05-30", startTime: "10:45" }],
@@ -5403,6 +5420,10 @@ export const KENNELS: KennelSeed[] = [
     },
     {
       kennelCode: "slut-h3", shortName: "SL,UT Discovery", fullName: "SL,UT Discovery Hash House Harriers",
+      // #2308: explicit slug — toSlug("SL,UT Discovery") now correctly strips the comma to
+      // "sl-ut-discovery", but the stored row predates that fix and needs a one-time correction
+      // (see companion data migration). Pin it explicitly so it can never drift back.
+      slug: "sl-ut-discovery",
       region: "Salt Lake City, UT",
       website: "https://www.whoremanh3.com",
       scheduleFrequency: "Monthly",
@@ -5711,6 +5732,7 @@ export const KENNELS: KennelSeed[] = [
     // Toulouse (first Toulouse kennel) — HC batch
     { kennelCode: "toulouse-h3", shortName: "Toulouse H3", fullName: "Toulouse Hash House Harriers",
       region: "Toulouse", country: "France", website: "https://toulousehash.com", facebookUrl: "https://www.facebook.com/ToulouseHHH",
+      contactEmail: "contact@toulousehash.com", // #2608: toulousehash.com/hash-contacts/
       logoUrl: "/kennel-logos/toulouse-h3.avif", scheduleDayOfWeek: "Sunday", scheduleFrequency: "Monthly",
       scheduleNotes: "Monthly, second Sunday (date can shift). Family-oriented — runners and walkers of all ages.",
       hashCash: "€5", foundedYear: 2002,
@@ -5879,6 +5901,7 @@ export const KENNELS: KennelSeed[] = [
       country: "Poland",
       website: "https://warsawh3.com/",
       facebookUrl: "https://www.facebook.com/WarsawH3",
+      contactEmail: "WarsawH3@gmail.com", // #2613: mailto in site footer
       foundedYear: 1983,
       hashCash: "PLN20", // first run free
       walkersWelcome: true,


### PR DESCRIPTION
⚠️ **MIGRATION WARNING**: This PR contains a Prisma data migration (`prisma/migrations/20260813120000_profiles_audit_quickwin_bundle_2649_2308/`). Vercel runs `prisma migrate deploy` on **every** build, including the PREVIEW build for this draft PR — so **pushing this branch has already applied the migration to the PRODUCTION database**, regardless of whether this PR is ever merged. Migration files are immutable once applied; any correction needs a forward revert migration, not an edit to this file.

## Summary

Kennel profile metadata sweep — quick-win bundle covering 12 audit findings. Each issue body already contained the verified value and its source; this PR applies each value to both `prisma/seed-data/kennels.ts` (provenance) and a companion data migration (the actual mechanism that reaches prod, since Vercel never runs `prisma db seed`).

## Issues applied

| Issue | Kennel | Field(s) | Value | Type |
|---|---|---|---|---|
| #2649 | Queens (qbk) | website, scheduleNotes, description | `https://hashnyc.com`; "Random days, random times."; full description text | null-fill |
| #2644 | Wasatch H3 | facebookUrl | `https://facebook.com/groups/UtahH3` (Utah H3 umbrella group) | null-fill |
| #2633 | WSH3 | contactEmail | `wileyzachary2@gmail.com` (2025 SOEX organizer contact — rotates yearly, lower confidence, most recent value chosen) | null-fill |
| #2627 | TNTH3 | foundedYear | `1984` (edinburghh3.com history page) | null-fill |
| #2617 | West London H3 | hashCash, facebookUrl, contactEmail, description | `£2 per run (£35/year membership)`; `https://www.facebook.com/groups/1822849584637512`; `westlondonh3@gmail.com`; about-page description | null-fill |
| #2613 | Warsaw H3 | contactEmail | `WarsawH3@gmail.com` | null-fill |
| #2610 | W3H3 | foundedYear, contactEmail | `2019` (Hareline sheet Hash #1); `w3h3hareraiser@gmail.com` | null-fill |
| #2608 | Toulouse H3 | contactEmail | `contact@toulousehash.com` | null-fill |
| #2578 | Fengyuan H3 (fishhh) | facebookUrl | `https://www.facebook.com/TWFISH3` | null-fill |
| #2516 | Southern Comfort H3 | — | **no action** — the issue itself reports no field is verifiable without a live source; nothing to apply, not closed | n/a |
| #2512 | SLUT H3 | foundedYear | `2023` — corrects the wrong "Since first known run in 2025" display. Atlanta Hash Board's oldest SLUT topic is #247 (Jun 2023); run numbering implies the kennel predates the forum, so this is a verified floor, not the exact founding year. Guarded to only fire when current value is NULL or later than 2023, so it won't clobber a more precise value set later. | **correction** |
| #2308 | SL,UT Discovery | slug | `sl-ut-discovery` (was the literal `sl,ut-discovery`, which 404s `/kennels/<slug>` since the comma never resolves through the route, encoded or not) | **correction** |

11 of 12 issues got a value applied (9 null-fills, 2 corrections); #2516 was excluded because its own body says nothing is verifiable yet.

## #2308 special case

Confirmed `toSlug()` (`src/lib/kennel-utils.ts`) already strips commas correctly — no code change needed. The bug was purely a stale `Kennel.slug` row predating that fix. **Not touched**: `toSlug()` itself.

While in there, audited all 515 kennel slugs for drift from `toSlug(shortName)`. Found 27 mismatches, but every one is intentional disambiguation (either an explicit `slug` override in the seed for a name collision — e.g. the two kennels both named "AH3" — or a `kennelCode`-fallback slug the seeder chose automatically to avoid a collision). None have invalid URL characters and none would be safe to "fix" toward raw `toSlug(shortName)` output, since doing so would create duplicate-slug collisions. No other stale slugs found.

## Null-fill vs. correction

Null-fills use `COALESCE` guarded by an empty-column check — idempotent, re-running touches 0 rows, and an admin edit is never stomped. #2512 and #2308 use explicit `UPDATE`s instead because they replace a wrong/stale value rather than filling an empty column, per the project's established pattern (see `20260707120000_profiles_audit_null_fills`).

`updatedAt` is `timestamp without time zone`, stamped with `NOW() AT TIME ZONE 'UTC'` throughout.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint` (0 errors; pre-existing unrelated warnings only)
- [x] `npm test` (340 test files / 9998 tests passed)
- [x] Read-only prod queries confirmed current column state for all 12 kennels before writing the migration guards

Closes #2649
Closes #2644
Closes #2633
Closes #2627
Closes #2617
Closes #2613
Closes #2610
Closes #2608
Closes #2578
Closes #2512
Closes #2308

🤖 Generated with [Claude Code](https://claude.com/claude-code)
